### PR TITLE
Tim sim analysis

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,11 @@
     "font-awesome": "^4.7.0",
     "js-yaml": "^3.12.0",
     "lodash": "^4.17.11",
+    "phenogrid": "^1.3.11",
     "register-service-worker": "^1.5.2",
     "underscore": "^1.9.1",
     "vue": "^2.5.17",
+    "vue-d3": "^0.1.0",
     "vue-form-wizard": "^0.8.4",
     "vue-json-tree": "^0.3.3",
     "vue-router": "^3.0.2"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "register-service-worker": "^1.5.2",
     "underscore": "^1.9.1",
     "vue": "^2.5.17",
-    "vue-d3": "^0.1.0",
     "vue-form-wizard": "^0.8.4",
     "vue-json-tree": "^0.3.3",
     "vue-router": "^3.0.2"

--- a/src/api/BioLink.js
+++ b/src/api/BioLink.js
@@ -404,14 +404,10 @@ export function getNodeLabelByCurie(curie) {
   return returnedPromise;
 }
 
-export function comparePhenotypes(phenotypesList, geneList, species = 'all', mode = 'search') {
-  const baseUrl = 'https://beta.monarchinitiative.org/analyze/phenotypes.json?';
+export function comparePhenotypes(phenotypesList, matcher) {
+  const baseUrl = `http://owlsim3-dev.monarchinitiative.org/api/match/${matcher}?`;
   const params = new URLSearchParams();
-  const phenoCuries = phenotypesList.map(elem => elem.curie);
-  params.append('input_items', phenoCuries);
-  params.append('gene_items', geneList);
-  params.append('target_species', species);
-  params.append('mode', mode);
+  phenotypesList.map(elem => params.append('id', elem.curie));
   const returnedPromise = new Promise((resolve, reject) => {
     axios.get(baseUrl, { params })
       .then((resp) => {

--- a/src/components/MonarchAutocomplete.vue
+++ b/src/components/MonarchAutocomplete.vue
@@ -6,7 +6,6 @@
     }"
     class="monarch-autocomplete autocomplete autorootdiv"
   >
-
     <div
       :class="{'input-group-sm': !homeSearch}"
       class="input-group"
@@ -40,7 +39,7 @@
         class="form-control xform-control-sm"
         type="text"
         autofocus="autoFocus"
-        placeholder="Search for phenotypes, diseases, genes..."
+        :placeholder="placeholderText"
         @input="debounceInput"
         @keydown="inputChanged"
         @keydown.enter="enter"
@@ -176,6 +175,11 @@ export default {
     }
   },
   props: {
+    placeholderText: {
+      type:String,
+      required:false,
+      default: "Search for phenotypes, diseases, genes...",
+    },
     showSearchButton: {
       type: Boolean,
       required: false,
@@ -222,6 +226,10 @@ export default {
       if (!this.value) {
         this.open = false;
       }
+    },
+    singleCategory() {
+      this.selected = [];
+      this.selected.push(this.singleCategory);
     },
     selected(newValue) {
       if (!this.singleCategory) {

--- a/src/components/PhenotypesTable.vue
+++ b/src/components/PhenotypesTable.vue
@@ -2,64 +2,65 @@
   <div>
     <div v-if="dataFetched">
       <b-table
-        :items="items"
-        :fields="fields"
-        :current-page="currentPage"
-        :per-page="rowsPerPage"
-        responsive="true"
-        class="table-border-soft"
+          :items="items"
+          :fields="fields"
+          :current-page="currentPage"
+          :per-page="rowsPerPage"
+          responsive="true"
+          class="table-border-soft"
+          @row-clicked="clickedRow"
       >
         <template
-          slot="hit"
-          slot-scope="data"
+            slot="hit"
+            slot-scope="data"
         >
           <strong>{{ data.item.hitLabel }}</strong>
         </template>
         <template
-          slot="combined_score"
-          slot-scope="data"
+            slot="combined_score"
+            slot-scope="data"
         >
           {{ data.item.combinedScore }}
         </template>
         <template
-          slot="most_informative_shared_phenotype"
-          slot-scope="data"
+            slot="most_informative_shared_phenotype"
+            slot-scope="data"
         >
           <router-link
-            :to="data.item.mostInformativeLink">
+              :to="data.item.mostInformativeLink">
             {{ data.item.mostInformativeLabel }}
           </router-link>
 
         </template>
         <template
-          slot="misp_ic"
-          slot-scope="data"
+            slot="misp_ic"
+            slot-scope="data"
         >
           {{ data.item.mostInformativeIc }}
         </template>
         <template
-          slot="other_matching_phenotypes"
-          slot-scope="data"
+            slot="other_matching_phenotypes"
+            slot-scope="data"
         >
           <router-link :to="data.item.otherMatchLink">
             {{ data.item.otherMatchLabel }}
           </router-link>
         </template>
         <template
-          slot="omp_ic"
-          slot-scope="data"
+            slot="omp_ic"
+            slot-scope="data"
         >
           {{ data.item.otherMatchIc }}
         </template>
       </b-table>
       <div v-if="items.length > 10">
         <b-pagination
-          v-model="currentPage"
-          :per-page="rowsPerPage"
-          :total-rows="items.length"
-          class="my-1"
-          align="center"
-          size="md"
+            v-model="currentPage"
+            :per-page="rowsPerPage"
+            :total-rows="items.length"
+            class="my-1"
+            align="center"
+            size="md"
         />
       </div>
     </div>
@@ -67,113 +68,112 @@
   </div>
 </template>
 <script>
-import * as BL from '@/api/BioLink';
+  import * as BL from '@/api/BioLink';
 
-export default {
-  props: {
-    phenotypes: {
-      type: Array,
-      required: true
+  export default {
+    props: {
+      phenotypes: {
+        type: Array,
+        required: true
+      },
+      matcher: {
+        type: String,
+        required: true
+      },
     },
-    genes: {
-      type: Array,
-      required: true
-    }
-  },
-  data() {
-    return {
-      dataFetched: false,
-      rowsPerPage: 10,
-      currentPage: 1,
-      fields: [
-        {
-          key: 'hit',
-          sortable: true
-        },
-        {
-          key: 'combined_score',
-          sortable: true
-        },
-        {
-          key: 'most_informative_shared_phenotype',
-          sortable: true
-        },
-        {
-          key: 'misp_ic',
-          sortable: true,
-          label: 'MISP IC'
-        },
-        {
-          key: 'other_matching_phenotypes',
-          sortable: true
-        },
-        {
-          key: 'omp_ic',
-          sortable: true,
-          label: 'OMP IC'
-        }
-      ],
-      items: [],
-      preItems: []
-    };
-  },
-  watch: {
-    phenotypes() {
+    data() {
+      return {
+        dataFetched: false,
+        rowsPerPage: 10,
+        currentPage: 1,
+        fields: [
+          { key: 'hitLabel',
+            label: 'Match Label',
+            sortable: true
+          },
+          { key: 'hitId',
+            label: 'Match Identifier',
+            sortable: true
+          },
+          { key: 'percentScore',
+            label: 'Percentage Score',
+            sortable: true
+          },
+          {
+            label: 'Rank',
+            key: 'rank',
+            sortable: true,
+          },
+          {
+            label: 'Raw Score',
+            key: 'rawScore',
+            sortable: true
+          },
+          {
+            label: 'Score',
+            key: 'score',
+            sortable: true,
+          },
+          {
+            label: 'Signifcance',
+            key: 'signifcance',
+            sortable: true,
+          }
+        ],
+        items: [],
+        preItems: []
+      };
+    },
+    watch: {
+      phenotypes() {
+        this.comparePhenotypes();
+      },
+      preItems() {
+        this.processItems();
+      },
+      matcher() {
+        this.comparePhenotypes();
+      },
+    },
+    mounted() {
       this.comparePhenotypes();
     },
-    preItems() {
-      this.processItems();
-    }
-  },
-  mounted() {
-    this.comparePhenotypes();
-  },
-  methods: {
-    async comparePhenotypes() {
-      const that = this;
-      try {
-        const searchResponse = await BL.comparePhenotypes(this.phenotypes, this.genes);
-
-        this.preItems = searchResponse;
-        this.dataFetched = true;
-      }
-      catch (e) {
-        that.dataError = e;
-        console.log('BioLink Error', e);
-      }
-    },
-    processItems() {
-      this.items = [];
-      this.preItems.data.results.forEach((elem) => {
-        const rowData = {
-          hitLabel: elem.j.label,
-          hitId: elem.j.id,
-          mostInformativeId: elem.maxIC_class.id,
-          mostInformativeIc: this.round(elem.maxIC_class.IC, 2),
-          mostInformativeLabel: elem.maxIC_class.label,
-          mostInformativeLink: `/phenotype/${elem.maxIC_class.id}`,
-          combinedScore: elem.combinedScore,
-          otherMatchId: '',
-          otherMatchLabel: '',
-          otherMatchIc: '',
-          otherMatchLink: ''
-        };
-        elem.matches.forEach((match) => {
-          if (match.lcs.id !== rowData.hitId) {
-            rowData.otherMatchIc = this.round(match.lcs.IC, 2);
-            rowData.otherMatchId = match.lcs.id;
-            rowData.otherMatchLabel = match.lcs.label;
-            rowData.otherMatchLink = `/phenotype/${match.lcs.id}`;
-          }
+    methods: {
+      async comparePhenotypes() {
+        const that = this;
+        try {
+          const searchResponse = await BL.comparePhenotypes(this.phenotypes, this.matcher);
+          this.preItems = searchResponse.data.matches;
+          this.dataFetched = true;
+        }
+        catch (e) {
+          that.dataError = e;
+          console.log('BioLink Error', e);
+        }
+      },
+      clickedRow(row) {
+        this.$router.push({ path: `/disease/${row.hitId}/` })
+      },
+      processItems() {
+        this.items = [];
+        this.preItems.forEach((elem) => {
+          const rowData = {
+            hitLabel: elem.matchLabel,
+            hitId: elem.matchId,
+            percentScore: elem.percentageScore,
+            rank: elem.rank,
+            rawScore: elem.rawScore,
+            score: elem.score,
+            significance: elem.significance,
+          };
+          this.items.push(rowData);
         });
-        this.items.push(rowData);
-      });
-    },
-    round(value, decimals) {
-      return value.toFixed(decimals);
+      },
+      round(value, decimals) {
+        return value.toFixed(decimals);
+      }
     }
-  }
-};
+  };
 </script>
 <style>
 

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,6 @@ import '@babel/polyfill';
 import Vue from 'vue';
 import BootstrapVue from 'bootstrap-vue/dist/bootstrap-vue.esm';
 import 'bootstrap-vue/dist/bootstrap-vue.css';
-import VueD3 from 'vue-d3';
 
 import router from './router';
 // import './registerServiceWorker';
@@ -12,7 +11,6 @@ import '@/style/debug-logo-animation.scss';
 
 
 Vue.config.productionTip = false;
-Vue.use(VueD3);
 Vue.use(BootstrapVue);
 
 

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,7 @@ import '@babel/polyfill';
 import Vue from 'vue';
 import BootstrapVue from 'bootstrap-vue/dist/bootstrap-vue.esm';
 import 'bootstrap-vue/dist/bootstrap-vue.css';
+import VueD3 from 'vue-d3';
 
 import router from './router';
 // import './registerServiceWorker';
@@ -11,8 +12,9 @@ import '@/style/debug-logo-animation.scss';
 
 
 Vue.config.productionTip = false;
-
+Vue.use(VueD3);
 Vue.use(BootstrapVue);
+
 
 new Vue({
   router,

--- a/src/views/AnalyzePhenotypes.vue
+++ b/src/views/AnalyzePhenotypes.vue
@@ -3,104 +3,64 @@
     <div class="row wizard-style">
       <div class="col-1"/>
       <div class="col-10 card card-body">
-        <form-wizard
-          title="Analyze Phenotypes"
-          shape="circle"
-          subtitle="A tool for ontological comparison of phenotype sets"
-          color="darkgrey"
-          finish-button-text="Submit and Analyze"
-          @on-complete="generatePhenogridData()"
+        <span  style="text-align: center; margin-bottom: 15px;"><h1>Phenotype Similarity Search</h1></span>
+        <h4>Create A Profile of Phenotypes</h4>
+        <div class="row">
+          <div class="col-2">
+            <b-form-group v-b-tooltip.hover.bottomright title="Search for phenotypes individually or a set of phenotypes by a disease">
+              <b-form-radio-group id="category"
+                                  buttons
+                                  button-variant="outline-info"
+                                  size="sm"
+                                  v-model="searchSelected"
+                                  :options="searchType"
+                                  name="radioBtnOutline"/>
+            </b-form-group>
+          </div>
+          <div class="col-8"></div>
+          <div class="col-2" style="float:right">
+            <b-form-group v-b-tooltip.hover.bottomright title="Select a matching algorhithm">
+              <b-form-radio-group id="matchers"
+                                  buttons
+                                  button-variant="outline-info"
+                                  size="sm"
+                                  v-model="matcherSelected"
+                                  :options="matchers"
+                                  name="radioBtnOutline"/>
+            </b-form-group>
+          </div>
+        </div>
+        <monarch-autocomplete
+            :show-search-button="false"
+            :home-search="false"
+            :placeholder-text="phText"
+            :single-category="searchSelected"
+            @interface="handlePhenotypes"s
+        />
+        <b-form-textarea
+            id="textarea1"
+            v-model="phenoCurieList"
+            :rows="3"
+            :max-rows="6"
+            placeholder="Enter a comma separated list of prefixed phenotype ids e.g. HP:0000322"
+            class="my-2"
+        />
+
+        <div v-if="phenoCurieList"
+             class="btn btn-outline-info"
+             @click="generatePGDataFromPhenotypeList"
         >
-          <tab-content title="Create A Profile of Phenotypes">
-            <monarch-autocomplete
-              :home-search="true"
-              single-category="phenotype"
-              @interface="handlePhenotypes"
-            />
-            <b-form-textarea
-              id="textarea1"
-              v-model="phenoCurieList"
-              :rows="3"
-              :max-rows="6"
-              placeholder="Enter a comma separated list of prefixed phenotype ids e.g. HP:0000322"
-              class="my-2"
-            />
-            <div
-              class="btn btn-success btn-sm"
-              @click="generatePGDataFromPhenotypeList"
-            >
-              Submit Phenotype List
-            </div>
-            <b-alert
-              :show="showPhenotypeAlert"
-              variant="danger"
-              class="my-2"
-              dismissible
-              @dismissed="showPhenotypeAlert=false"
-            >
-              Error: '{{ rejectedPhenotypeCuries }}' Please enter phenotype curies from HP, MP, or ZP!
-            </b-alert>
-          </tab-content>
-          <tab-content title="Select Comparables">
-            <div class="row">
-              <div class="col-3">
-                <b-form-group>
-                  <b-form-checkbox-group
-                    id="btnradios1"
-                    v-model="selectedGroups"
-                    :options="groupOptions"
-                    buttons
-                    stacked
-                    size="sm"
-                    name="radiosBtnDefault"
-                  />
-                </b-form-group>
-              </div>
-              <div class="col-9">
-                <monarch-autocomplete
-                  :home-search="true"
-                  single-category="gene"
-                  @interface="handleGenes"
-                />
-                <b-form-textarea
-                  id="textarea1"
-                  v-model="geneCurieList"
-                  :rows="3"
-                  :max-rows="6"
-                  placeholder="Enter a comma seperated list of gene ids"
-                  class="my-3"
-                />
-                <div class="form-group">
-                  <div
-                    class="btn btn-success btn-sm"
-                    @click="geneListLookup"
-                  >
-                    Submit Gene List
-                  </div>
-                  <b-form-radio-group
-                    v-model="geneCurieType"
-                    :options="geneCurieTypeOptions"
-                    buttons
-                    button-variant="primary"
-                    size="sm"
-                  />
-                </div>
-                <b-alert
-                  :show="showGeneAlert"
-                  variant="danger"
-                  class="my-2"
-                  dismissible
-                  @dismissed="showGeneAlert=false"
-                >
-                  Error: Please enter a valid gene identifier!
-                </b-alert>
-              </div>
-            </div>
-          </tab-content>
-          <tab-content
-            title="Run Analyses"
-          />
-        </form-wizard>
+          Submit Phenotype List
+        </div>
+        <b-alert
+            :show="showPhenotypeAlert"
+            variant="danger"
+            class="my-2"
+            dismissible
+            @dismissed="showPhenotypeAlert=false"
+        >
+          Error: '{{ rejectedPhenotypeCuries }}' Please enter phenotype curies from HP, MP, or ZP!
+        </b-alert>
       </div>
       <div class="col-1"/>
     </div>
@@ -108,77 +68,52 @@
     <!--results below here-->
     <div v-if="phenotypes.length">
       <div
-        class="row my-2"
+          class="row my-2"
       >
-        <div class="col-1"/>
         <div class="col-1">
-
-          <svg
-            height="100"
-            width="100"
-          >
-            <circle
-              cx="50"
-              cy="50"
-              r="40"
-              stroke-width="3"
-              fill="darkgrey"
-            />
-            <text
-              x="50%"
-              y="50%"
-              text-anchor="middle"
-              stroke="white"
-              stroke-width="3px"
-              dy=".3em"
-              font-style="italic"
-            >
-              1
-            </text>
-          </svg>
         </div>
-        <div class="col-9 card">
+        <div class="col-10 card">
           <div class="p-3">
             <h4>Phenotype Profile</h4>
             <div class="flex-container">
               <div
-                v-for="(phenotype, index) in phenotypes"
-                :key="phenotype.curie"
-                class="m-1"
+                  v-for="(phenotype, index) in phenotypes"
+                  :key="phenotype.curie"
+                  class="m-1"
               >
                 <div
-                  class="btn-group"
-                  role="group"
+                    class="btn-group"
+                    role="group"
                 >
                   <button
-                    v-b-modal="phenotype.curie"
-                    class="btn btn-sm btn-info"
+                      v-b-modal="phenotype.curie"
+                      class="btn btn-sm btn-info"
                   >
                     {{ phenotype.match }} ({{ phenotype.curie }})
                   </button>
                   <button
-                    type="button"
-                    class="btn btn-sm btn-info"
-                    @click="popPhenotype(index)"
+                      type="button"
+                      class="btn btn-sm btn-info"
+                      @click="popPhenotype(index)"
                   >
                     <strong>x</strong>
                   </button>
                 </div>
                 <b-modal
-                  :id="phenotype.curie"
-                  size="lg"
-                  title="phenotype.label"
+                    :id="phenotype.curie"
+                    size="lg"
+                    title="phenotype.label"
                 >
                   <div
-                    slot="modal-title"
-                    class="w-100"
+                      slot="modal-title"
+                      class="w-100"
                   >
                     {{ phenotype.match }} | {{ phenotype.curie }}
                   </div>
                   <div>
                     <local-nav
-                      :anchor-id="phenotype.curie"
-                      @interface="handleReplacePhenotype"
+                        :anchor-id="phenotype.curie"
+                        @interface="handleReplacePhenotype"
                     />
                   </div>
                 </b-modal>
@@ -189,110 +124,39 @@
         <div class="col-1"/>
       </div>
     </div>
-    <div v-if="showComparableList">
-      <div class="row my-2">
-        <div class="col-1"/>
-        <div class="col-1">
-          <svg
-            height="100"
-            width="100"
-          >
-            <circle
-              cx="50"
-              cy="50"
-              r="40"
-              stroke-width="3"
-              fill="darkgrey"
-            />
-            <text
-              x="50%"
-              y="50%"
-              text-anchor="middle"
-              stroke="white"
-              stroke-width="3px"
-              dy=".3em"
-              font-style="italic"
-            >
-              2
-            </text>
-          </svg>
+    <div  v-if="phenotypes.length"
+          class="row">
+      <div class="col-1"></div>
+      <div class="col-10 card p-0 my-5">
+        <div class="btn btn-outline-success"
+             @click="generatePhenogridData()"
+        >
+          Run Similarity Analysis
         </div>
-        <div class="col-9 card">
-          <div class="p-3">
-            <h4>Comparables</h4>
-            <div class="flex-container">
-              <div
-                v-for="(group, index) in selectedGroups"
-                :key="group.id"
-                class="m-1"
-              >
-                <div
-                  class="btn-group"
-                  role="group"
-                >
-                  <button class="btn btn-sm btn-success">
-                    {{ group.groupName }}
-                  </button>
-                  <button
-                    type="button"
-                    class="btn btn-sm btn-success"
-                    @click="popGroup(index)"
-                  >
-                    <strong>x</strong>
-                  </button>
-                </div>
-              </div>
-            </div>
-            <div class="flex-container">
-              <div
-                v-for="(gene, index) in genes"
-                :key="gene.curie"
-                class="m-1"
-              >
-                <div
-                  class="btn-group"
-                  role="group">
-                  <button class="btn btn-sm btn-warning">
-                    {{ gene.match }}
-                  </button>
-                  <button
-                    type="button"
-                    class="btn btn-sm btn-warning"
-                    @click="popGene(index)"
-                  >
-                    <strong>x</strong>
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="col-1"/>
       </div>
+      <div class="col-1"></div>
     </div>
-    <div class="row my-3">
-      <div class="col-1"/>
-      <div
-        v-show="showPhenogrid"
-        class="col-10 card"
-      >
-        <pheno-grid
-          :x-axis="xAxis"
-          :y-axis="yAxis"
-          :index="pgIndex"
-          :mode="mode"
-        />
-      </div>
-      <div class="col-1"/>
-    </div>
+    <!--<div class="row">-->
+      <!--<div class="col-1"/>-->
+      <!--<div-->
+          <!--v-show="showPhenogrid"-->
+          <!--class="col-10 card"-->
+      <!--&gt;-->
+        <!--<pheno-grid-->
+            <!--:x-axis="xAxis"-->
+            <!--:y-axis="yAxis"-->
+        <!--/>-->
+      <!--</div>-->
+      <!--<div class="col-1"/>-->
+    <!--</div>-->
     <div
-      v-if="showPhenogrid"
-      class="row my-3">
+        v-if="showPhenogrid"
+        class="row my-3">
       <div class="col-1"/>
-      <div class="col-10">
+      <div class="col-10 card card-body">
         <phenotypes-table
-          :genes="genes"
-          :phenotypes="phenotypes"
+            :phenotypes="phenotypes"
+            :matcher="matcherSelected"
         />
       </div>
       <div class="col-1"/>
@@ -301,210 +165,265 @@
 </template>
 
 <script>
-import Vue from 'vue';
-import VueFormWizard from 'vue-form-wizard';
-import 'vue-form-wizard/dist/vue-form-wizard.min.css';
-import * as BL from '@/api/BioLink';
-import MonarchAutocomplete from '@/components/MonarchAutocomplete.vue';
-import PhenoGrid from '@/components/PhenoGrid.vue';
-import LocalNav from '@/components/LocalNav.vue';
-import PhenotypesTable from '@/components/PhenotypesTable.vue';
+  import Vue from 'vue';
+  import VueFormWizard from 'vue-form-wizard';
+  import 'vue-form-wizard/dist/vue-form-wizard.min.css';
+  import * as BL from '@/api/BioLink';
+  import MonarchAutocomplete from '@/components/MonarchAutocomplete.vue';
+  import PhenoGrid from '@/components/PhenoGrid.vue';
+  import LocalNav from '@/components/LocalNav.vue';
+  import PhenotypesTable from '@/components/PhenotypesTable.vue';
 
-Vue.use(VueFormWizard);
+  Vue.use(VueFormWizard);
 
-const findIndex = require('lodash/findIndex');
+  const findIndex = require('lodash/findIndex');
 
-export default {
-  name: 'AnalyzePhenotypes',
-  components: {
-    'monarch-autocomplete': MonarchAutocomplete,
-    'pheno-grid': PhenoGrid,
-    'phenotypes-table': PhenotypesTable,
-    'local-nav': LocalNav,
-  },
-  data() {
-    return {
-      mode: 'search',
-      showPhenogrid: false,
-      pgIndex: 0,
-      rejectedPhenotypeCuries: [],
-      showGeneAlert: false,
-      showPhenotypeAlert: false,
-      phenoCurieList: 'HP:0000322,HP:0000303,HP:0000316,HP:0000272',
-      geneCurieList: '5290, 5728, 324, 7428, 3845',
-      messages: [],
-      phenotypes: [],
-      genes: [],
-      selectedGroups: [],
-      yAxis: [],
-      xAxis: [],
-      geneCurieType: 'NCBIGene',
-      geneCurieTypeOptions: [
-        {
-          text: 'NCBI Gene ID',
-          value: 'NCBIGene'
-        },
-        {
-          text: 'Ensemble Gene ID',
-          value: 'ENSEMBL'
-        },
-        {
-          text: 'HGNC Gene ID',
-          value: 'HGNC'
+  export default {
+    name: 'AnalyzePhenotypes',
+    components: {
+      'monarch-autocomplete': MonarchAutocomplete,
+      'pheno-grid': PhenoGrid,
+      'phenotypes-table': PhenotypesTable,
+      'local-nav': LocalNav,
+    },
+    data() {
+      return {
+        matcherSelected: 'phenodigm',
+        matchers: [
+          { text: 'Phenodigm', value: 'phenodigm' },
+          { text: 'Jaccard', value: 'jaccard' },
+        ],
+        searchSelected: 'Phenotype',
+        searchType: [
+          { text: 'Phenotype', value: 'Phenotype' },
+          { text: 'Disease', value: 'disease' },
+        ],
+        acceptedPrefixes:['HP', 'MP', 'ZP'],
+        mode: 'search',
+        showPhenogrid: false,
+        pgIndex: 0,
+        rejectedPhenotypeCuries: [],
+        showGeneAlert: false,
+        showPhenotypeAlert: false,
+        phenoCurieList: '',
+        geneCurieList: '5290, 5728, 324, 7428, 3845',
+        messages: [],
+        phenotypes: [],
+        genes: [],
+        selectedGroups: [],
+        yAxis: [],
+        xAxis: [],
+        geneCurieType: 'NCBIGene',
+        geneCurieTypeOptions: [
+          {
+            text: 'NCBI Gene ID',
+            value: 'NCBIGene'
+          },
+          {
+            text: 'Ensemble Gene ID',
+            value: 'ENSEMBL'
+          },
+          {
+            text: 'HGNC Gene ID',
+            value: 'HGNC'
+          }
+        ],
+        groupOptions: [
+          {
+            text: 'Mus musculus (genes)',
+            value: {
+              groupId: '10090',
+              groupName: 'Mus musculus'
+            }
+          },
+          // {
+          //   text: 'Homo sapiens (diseases)',
+          //   value: {
+          //     groupId: '9606',
+          //     groupName: 'Homo sapiens'
+          //   }
+          // },
+          {
+            text: 'Drosophila melanogaster (genes)',
+            value: {
+              groupId: '7227',
+              groupName: 'Drosophila melanogaster'
+            }
+          },
+          {
+            text: 'Caenorhabditis elegans (genes)',
+            value: {
+              groupId: '6239',
+              groupName: 'Caenorhabditis elegans'
+            }
+          },
+          {
+            text: 'Danio rerio (genes)',
+            value: {
+              groupId: '7955',
+              groupName: 'Danio rerio'
+            }
+          }
+        ]
+      };
+    },
+    computed: {
+      phText() {
+        return `Search for ${this.firstLower(this.searchSelected)}s by keyword or identifier`;
+      },
+      showComparableList() {
+        let show = false;
+        if (this.phenotypes.length) {
+          if (this.genes.length || this.selectedGroups.length) {
+            show = true;
+          }
         }
-      ],
-      groupOptions: [
-        {
-          text: 'Mus musculus (genes)',
-          value: {
-            groupId: '10090',
-            groupName: 'Mus musculus'
-          }
-        },
-        // {
-        //   text: 'Homo sapiens (diseases)',
-        //   value: {
-        //     groupId: '9606',
-        //     groupName: 'Homo sapiens'
-        //   }
-        // },
-        {
-          text: 'Drosophila melanogaster (genes)',
-          value: {
-            groupId: '7227',
-            groupName: 'Drosophila melanogaster'
-          }
-        },
-        {
-          text: 'Caenorhabditis elegans (genes)',
-          value: {
-            groupId: '6239',
-            groupName: 'Caenorhabditis elegans'
-          }
-        },
-        {
-          text: 'Danio rerio (genes)',
-          value: {
-            groupId: '7955',
-            groupName: 'Danio rerio'
-          }
-        }
-      ]
-    };
-  },
-  computed: {
-    showComparableList() {
-      let show = false;
-      if (this.phenotypes.length) {
-        if (this.genes.length || this.selectedGroups.length) {
-          show = true;
-        }
+        return show;
       }
-      return show;
-    }
-  },
-  methods: {
-    async fetchLabel(curie, curieType) {
-      const that = this;
-      try {
-        const searchResponse = await BL.getNodeLabelByCurie(curie);
-        if (curieType === 'phenotype') {
-          this.convertPhenotypes(searchResponse);
+    },
+    methods: {
+      firstLower(elem) {
+        return elem.charAt(0).toLowerCase() + elem.substr(1);
+      },
+      async fetchLabel(curie, curieType) {
+        const that = this;
+        try {
+          const searchResponse = await BL.getNodeLabelByCurie(curie);
+          if (curieType === 'phenotype') {
+            this.convertPhenotypes(searchResponse);
+            if (searchResponse.status === 500) {
+              this.showGeneAlert = false;
+            }
+          }
+          if (curieType === 'gene') {
+            this.convertGenes(searchResponse);
+            if (searchResponse.status === 500) {
+              this.showGeneAlert = true;
+            }
+          }
+        }
+        catch (e) {
+          that.dataError = e;
+          console.log('BioLink Error', e);
+        }
+      },
+      async fetchPhenotypes(curie) {
+        const that = this;
+        try {
+          const searchResponse = await BL.getNodeAssociations('disease', curie, 'phenotype' );
+          const index = findIndex(this.phenotypes, { curie: curie });
+          this.popPhenotype(index);
+          searchResponse.data.associations.forEach(elem => {
+            const elemIndex = findIndex(this.phenotypes, { curie: elem.object.id});
+            if (elemIndex === -1) {
+            this.convertPhenotypes({
+              data: {
+                id: elem.object.id,
+                label: elem.object.label,
+              }
+            });
+            }
+          });
           if (searchResponse.status === 500) {
             this.showGeneAlert = false;
           }
+
         }
-        if (curieType === 'gene') {
-          this.convertGenes(searchResponse);
-          if (searchResponse.status === 500) {
-            this.showGeneAlert = true;
-          }
+        catch (e) {
+          that.dataError = e;
+          console.log('BioLink Error', e);
         }
-      }
-      catch (e) {
-        that.dataError = e;
-        console.log('BioLink Error', e);
-      }
-    },
-    popPhenotype(ind) {
-      this.phenotypes.splice(ind, 1);
-    },
-    popGroup(ind) {
-      this.selectedGroups.splice(ind, 1);
-    },
-    popGene(ind) {
-      this.genes.splice(ind, 1);
-    },
-    handlePhenotypes(payload) {
-      this.phenotypes.push(payload);
-    },
-    handleReplacePhenotype(payload) {
-      const replaceIndex = findIndex(this.phenotypes, { curie: payload.root });
-      this.phenotypes.splice(replaceIndex, 1);
-      this.phenotypes.push(payload);
-    },
-    handleGenes(payload) {
-      this.genes.push(payload);
-    },
-    generatePhenogridData() {
-      this.showPhenogrid = true;
-      if (this.selectedGroups.length) {
-        this.xAxis = this.selectedGroups;
-      }
-      else {
-        this.xAxis = this.genes.map((elem) => {
-          this.mode = 'compare';
-          return elem.curie;
-        });
-      }
-      this.yAxis = this.phenotypes.map(elem => ({
-        id: elem.curie,
-        term: elem.match
-      }));
-      this.pgIndex += 1;
-    },
-    geneListLookup() {
-      this.genes = [];
-      this.geneCurieList.split(',').forEach((elem) => {
-        this.fetchLabel(`${this.geneCurieType}:${elem.trim()}`, 'gene');
-      });
-    },
-    generatePGDataFromPhenotypeList() {
-      this.rejectedPhenotypeCuries = [];
-      const acceptedPrefixes = [
-        'HP',
-        'MP',
-        'ZP'
-      ];
-      this.phenotypes = [];
-      this.phenoCurieList.split(',').forEach((elem) => {
-        const elemTrimmed = elem.trim();
-        const prefix = elemTrimmed.split(':')[0];
-        if (acceptedPrefixes.includes(prefix)) {
-          this.fetchLabel(elemTrimmed, 'phenotype');
+      },
+      containsObject(obj, list) {
+        return list.some(elem => elem === obj)
+      },
+      popPhenotype(ind) {
+        this.phenotypes.splice(ind, 1);
+      },
+      popGroup(ind) {
+        this.selectedGroups.splice(ind, 1);
+      },
+      popGene(ind) {
+        this.genes.splice(ind, 1);
+      },
+      handlePhenotypes(payload) {
+        if(payload.curie.includes('MONDO')) {
+          this.fetchPhenotypes(payload.curie);
+        }
+        this.phenotypes.push(payload);
+      },
+      handleReplacePhenotype(payload) {
+        const replaceIndex = findIndex(this.phenotypes, { curie: payload.root });
+        this.phenotypes.splice(replaceIndex, 1);
+        this.phenotypes.push(payload);
+      },
+      handleGenes(payload) {
+        this.genes.push(payload);
+      },
+      generatePhenogridData() {
+        this.showPhenogrid = true;
+        if (this.selectedGroups.length) {
+          this.xAxis = this.selectedGroups;
         }
         else {
-          this.rejectedPhenotypeCuries.push(elemTrimmed);
-          this.showPhenotypeAlert = true;
+          this.xAxis = [
+            {
+              "groupId": "9606",
+              "groupName": "Homo sapiens"
+            },
+            {
+              "groupId": "10090",
+              "groupName": "Mus musculus"
+            }
+          ];
+          // this.xAxis = this.genes.map((elem) => {
+          //   this.mode = 'compare';
+          //   return elem.curie;
+          // });
         }
-      });
-    },
-    convertGenes(elem) {
-      const geneData = elem.data;
-      this.genes.push({
-        curie: geneData.id,
-        match: geneData.label
-      });
-    },
-    convertPhenotypes(elem) {
-      const phenoData = elem.data;
-      this.phenotypes.push({
-        curie: phenoData.id,
-        match: phenoData.label
-      });
+        this.yAxis = this.phenotypes.map(elem => ({
+          id: elem.curie,
+          term: elem.match
+        }));
+        this.pgIndex += 1;
+      },
+      geneListLookup() {
+        this.genes = [];
+        this.geneCurieList.split(',').forEach((elem) => {
+          this.fetchLabel(`${this.geneCurieType}:${elem.trim()}`, 'gene');
+        });
+      },
+      generatePGDataFromPhenotypeList() {
+        this.rejectedPhenotypeCuries = [];
+        this.phenotypes = [];
+        this.phenoCurieList.split(',').forEach((elem) => {
+          const elemTrimmed = elem.trim();
+          const prefix = elemTrimmed.split(':')[0];
+          if (this.acceptedPrefixes.includes(prefix)) {
+            this.fetchLabel(elemTrimmed, 'phenotype');
+          }
+          else {
+            this.rejectedPhenotypeCuries.push(elemTrimmed);
+            this.showPhenotypeAlert = true;
+          }
+        });
+      },
+      convertGenes(elem) {
+        const geneData = elem.data;
+        this.genes.push({
+          curie: geneData.id,
+          match: geneData.label
+        });
+      },
+      convertPhenotypes(elem) {
+        const phenoData = elem.data;
+        this.phenotypes.push({
+          curie: phenoData.id,
+          match: phenoData.label
+        });
+      }
     }
-  }
-};
+  };
 </script>
 
 <style scoped>


### PR DESCRIPTION
Simple sim analysis tool to replace analyze phenotypes for the time being.  Uses Kent's OwlSim3 implementation.  Allows selecting sets of phenotypes based on disease, and allows to choose matcher between Jaccard and Phenodigm.  Can add more later.