### PR TITLE
Publish via Jenkins to alpha.m.org. Add bundle analyze. Reduce bundle size. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monarch-ui",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "scripts": {
     "clean": "rm -rf dist/",
@@ -9,6 +9,7 @@
     "serve": "node_modules/.bin/vue-cli-service serve --port 8081",
     "build": "node_modules/.bin/vue-cli-service build && cp dist/index.html dist/404.html",
     "buildandserve": "npm run build && (cd dist/ && ln -s . monarch-ui) && http-server -c-1 dist/",
+    "analyze": "BUILD=analyze node_modules/.bin/vue-cli-service build",
     "lint": "node_modules/.bin/vue-cli-service lint",
     "test:unit": "node_modules/.bin/vue-cli-service test:unit",
     "test:e2e": "node_modules/.bin/vue-cli-service test:e2e",
@@ -55,6 +56,7 @@
     "node-sass": "^4.11.0",
     "sass-loader": "^7.1.0",
     "vue-cli-plugin-bootstrap-vue": "^0.1.0",
+    "vue-cli-plugin-webpack-bundle-analyzer": "^1.2.0",
     "vue-markdown-loader": "^2.4.1",
     "vue-template-compiler": "^2.5.22"
   }

--- a/package.json
+++ b/package.json
@@ -5,15 +5,14 @@
   "scripts": {
     "clean": "rm -rf dist/",
     "rmdsstore": "find . -name '.DS_Store' -print -delete",
-    "ui": "npx vue ui",
-    "serve": "npx vue-cli-service serve --port 8081",
-    "build": "npx vue-cli-service build && cp dist/index.html dist/404.html",
+    "ui": "node_modules/.bin/vue ui",
+    "serve": "node_modules/.bin/vue-cli-service serve --port 8081",
+    "build": "node_modules/.bin/vue-cli-service build && cp dist/index.html dist/404.html",
     "buildandserve": "npm run build && (cd dist/ && ln -s . monarch-ui) && http-server -c-1 dist/",
-    "lint": "npx vue-cli-service lint",
-    "test:unit": "npx vue-cli-service test:unit",
-    "test:e2e": "npx vue-cli-service test:e2e",
-    "publish": "./publish.sh",
-    "oldpublish": "npm run build && git add -A dist/"
+    "lint": "node_modules/.bin/vue-cli-service lint",
+    "test:unit": "node_modules/.bin/vue-cli-service test:unit",
+    "test:e2e": "node_modules/.bin/vue-cli-service test:e2e",
+    "publish": "./publish.sh"
   },
   "dependencies": {
     "@babel/polyfill": "^7.2.5",

--- a/public/team.yaml
+++ b/public/team.yaml
@@ -183,7 +183,7 @@ institutions:
         title: Bioinformatician
         bio: Dr. Jacobsen has a BSc in Biochemistry from the Imperial College, London and a Ph.D. from the University of Cambridge, in Structural Biology. He has developed several tools for investigating the use of model organism phenotype data to better understand the role of gene mutation in human disease.
       - name: Tomasz Konopka
-        picture: /image/person-unknown.png
+        picture: img/team/person-unknown.png
         alumni: false
         title: Bioinformatician
         bio: Dr. Konopka has a PhD in physics from the University of Waterloo. Since turning to bioinformatics, he has developed computational methods for sequence-data analysis and contributed to characterizations of molecular signatures due to genetic mutations. He is interested in the mechanisms, uncertainties, and ambiguities associated with linking genotypes to phenotypes.

--- a/publish.sh
+++ b/publish.sh
@@ -1,9 +1,11 @@
+# publish.sh [remote_name]
+# [remote_name] Optional name of remote. Default is 'origin'
 #
-# Based upon:
-#	https://blog.bloomca.me/2017/12/15/how-to-push-folder-to-github-pages.html
+# Builds the application and pushes to the gh-pages branch of remote_name
 #
 
-REMOTE=`git remote get-url --push origin`
+REMOTENAME=${1:-origin}
+REMOTE=`git remote get-url --push ${REMOTENAME}`
 echo "REMOTE: ${REMOTE}"
 echo "INIT_CWD: ${INIT_CWD}"
 echo "PWD: ${PWD}"
@@ -12,10 +14,10 @@ echo "pwd: `pwd`"
 # exit
 
 rm -rf dist
-npm run build
+BUILD=nonrootdomain npm run build
 cd dist
 git init
 git add .
 git commit -m "Initial commit"
-git remote add origin ${REMOTE}
-git push --force origin master:gh-pages
+git remote add ${REMOTENAME} ${REMOTE}
+git push --force ${REMOTENAME} master:gh-pages

--- a/src/NOP.js
+++ b/src/NOP.js
@@ -1,0 +1,5 @@
+// Intentionally empty JS file to allow unused/unusable
+// modules to be satisfied via require
+
+module.exports = {
+};

--- a/src/api/Team.js
+++ b/src/api/Team.js
@@ -3,15 +3,12 @@ import yaml from 'js-yaml';
 
 export default async function getTeam() {
   const teamUrl = `${process.env.BASE_URL}team.yaml`;
-  console.log('getTeam', teamUrl);
   const teamResponse = await axios.get(teamUrl);
-  console.log('teamResponse', teamResponse);
 
   let team = null;
   try {
     const teamParsed = await yaml.safeLoad(teamResponse.data, 'utf8');
     const institutions = teamParsed.institutions;
-    console.log('teamParsed', teamParsed, institutions);
 
     institutions.forEach((i) => {
       i.logo = `${process.env.BASE_URL}${i.logo}`;

--- a/src/main.js
+++ b/src/main.js
@@ -38,3 +38,5 @@ debugSpinnerLink.addEventListener('click', () => {
   debugLogos[0].classList.toggle('rotate');
   debugLogos[1].classList.toggle('rotate');
 });
+
+window.MonarchUIVersion = '0.0.1';

--- a/src/main.js
+++ b/src/main.js
@@ -39,4 +39,4 @@ debugSpinnerLink.addEventListener('click', () => {
   debugLogos[1].classList.toggle('rotate');
 });
 
-window.MonarchUIVersion = '0.0.1';
+window.MonarchUIVersion = '0.0.2';

--- a/src/views/AboutTeam.md
+++ b/src/views/AboutTeam.md
@@ -204,7 +204,6 @@ export default {
   },
   async mounted() {
     this.institutions = (await getTeam()).institutions;
-    console.log('institutions', this.institutions);
   }
 };
 </script>

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,7 +1,8 @@
 const path = require('path');
 
+const analyze = process.env.BUILD === 'analyze';
 const nonrootdomain = process.env.BUILD === 'nonrootdomain';
-const publicPath = nonrootdomain ? '/monarch-ui/' : '/';
+const baseURL = nonrootdomain ? '/monarch-ui/' : '/';
 
 const markdownItClass = require('markdown-it');
 
@@ -24,22 +25,32 @@ mdLoaderPlain.raw = true;
 mdLoaderPlain.wrapper = 'div';
 mdLoaderPlain.wrapperClass = 'vue-markdown-plain';
 
-// const GenomeFeatureViewer = path.resolve(__dirname, '../GenomeFeatureComponent/dist/index.js');
-// const GenomeFeatureViewerCSS = path.resolve(__dirname, '../GenomeFeatureComponent/dist/GenomeFeatureViewer.css');
-const GenomeFeatureViewer = path.resolve(__dirname, 'node_modules/genomefeaturecomponent/dist/index.js');
-const GenomeFeatureViewerCSS = path.resolve(__dirname, 'node_modules/genomefeaturecomponent/dist/GenomeFeatureViewer.css');
+// const GenomeFeatureViewer = path.resolve(__dirname, 'node_modules/genomefeaturecomponent/dist/index.js');
+// const GenomeFeatureViewerCSS = path.resolve(__dirname, 'node_modules/genomefeaturecomponent/dist/GenomeFeatureViewer.css');
+const GenomeFeatureViewer = path.resolve(__dirname, 'node_modules/genomefeaturecomponent/src/index.js');
+const GenomeFeatureViewerCSS = path.resolve(__dirname, 'node_modules/genomefeaturecomponent/src/GenomeFeatureViewer.css');
+const esprima = path.resolve(__dirname, 'node_modules/genomefeaturecomponent/src/index.js');
 
-module.exports = {
+const vueConfig = {
   // outputDir: 'dist',
-  publicPath: publicPath,
+  publicPath: baseURL,
 
   lintOnSave: false,
+
+  pluginOptions: {
+    // https://github.com/mrbbot/vue-cli-plugin-webpack-bundle-analyzer
+    // https://github.com/webpack-contrib/webpack-bundle-analyzer#options-for-plugin
+    webpackBundleAnalyzer: {
+      analyzerMode: 'disabled',
+    }
+  },
 
   configureWebpack: {
     resolve: {
       alias: {
         'GenomeFeatureViewer': GenomeFeatureViewer,
         'GenomeFeatureViewerCSS': GenomeFeatureViewerCSS,
+        'esprima$': path.join(__dirname, 'src/NOP.js'),
       }
     }
   },
@@ -104,3 +115,9 @@ module.exports = {
   }
 
 };
+
+if (analyze) {
+  vueConfig.pluginOptions.webpackBundleAnalyzer.analyzerMode = 'server';
+}
+
+module.exports = vueConfig;

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,8 @@
 const path = require('path');
 
+const nonrootdomain = process.env.BUILD === 'nonrootdomain';
+const publicPath = nonrootdomain ? '/monarch-ui/' : '/';
+
 const markdownItClass = require('markdown-it');
 
 const mdLoader = markdownItClass({
@@ -28,7 +31,7 @@ const GenomeFeatureViewerCSS = path.resolve(__dirname, 'node_modules/genomefeatu
 
 module.exports = {
   // outputDir: 'dist',
-  publicPath: '/monarch-ui/',
+  publicPath: publicPath,
 
   lintOnSave: false,
 
@@ -100,18 +103,4 @@ module.exports = {
       });
   }
 
-/*
-const path = require('path');
-  // Based on:
-  //  https://github.com/vuejs/vue-cli/issues/1647#issuecomment-399093605
-  //
-  chainWebpack: config => {
-    config.plugin('define').tap(definitions => {
-      definitions[0] = Object.assign(definitions[0], {
-        'monarchNGPrelude': path.join(__dirname, 'src/style/variables.scss')
-      });
-      return definitions;
-    });
-  }
-*/
 };


### PR DESCRIPTION
- Use / as default for publicPath, unless overridden by BUILD=nonrootdomain, which will use /monarch-ui/ for publicPath.
- Eliminate use of npx, which was overkill.
- Adds 'npm run analyze' for bundle analysis.
- Compiles GenomeFeatureView to reduce bundle size.
- Ensure that esprima.js is not included in bundle by using a NOP.js file.
- Fix image reference for Tomasz on Team page.
- Bump version to 0.0.2 (mostly to ensure that I can detect the version. Going to automate this versioning in the future).
