### PR TITLE
0.0.7 - AnalyzePhenotypes fixes. ESLint changes. Code cleanup. Faster page load. Error handling.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = {
     'airbnb-base',
   ],
   rules: {
+    'no-plusplus': 0,
     'no-console': 0, // errorInProduction,
     'no-debugger': errorInProduction,
     'import/dynamic-import-chunkname': 'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "monarch-ui",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -38,18 +38,18 @@
       }
     },
     "@babel/core": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.3.3.tgz",
-      "integrity": "sha512-w445QGI2qd0E0GlSnq6huRZWPMmQGCp5gd5ZWS4hagn0EiwzxD5QMFkpchyusAyVC1n27OKXzQ0/88aVU9n4xQ==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.3.4.tgz",
+      "integrity": "sha512-jRsuseXBo9pN197KnDwhhaaBzyZr2oIcLHHTt2oDdQrej5Qp57dCCJafWx5ivU8/alEYDpssYqv1MUqcxwQlrA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.3.3",
+        "@babel/generator": "^7.3.4",
         "@babel/helpers": "^7.2.0",
-        "@babel/parser": "^7.3.3",
+        "@babel/parser": "^7.3.4",
         "@babel/template": "^7.2.2",
-        "@babel/traverse": "^7.2.2",
-        "@babel/types": "^7.3.3",
+        "@babel/traverse": "^7.3.4",
+        "@babel/types": "^7.3.4",
         "convert-source-map": "^1.1.0",
         "debug": "^4.1.0",
         "json5": "^2.1.0",
@@ -71,12 +71,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.3.tgz",
-      "integrity": "sha512-aEADYwRRZjJyMnKN7llGIlircxTCofm3dtV5pmY6ob18MSIuipHpA2yZWkPlycwu5HJcx/pADS3zssd8eY7/6A==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.4.tgz",
+      "integrity": "sha512-8EXhHRFqlVVWXPezBW5keTiQi/rJMQTg/Y9uVCEZ0CAF3PKtCCaVRnp64Ii1ujhkoDhhF1fVsImoN4yJ2uz4Wg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.3.3",
+        "@babel/types": "^7.3.4",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.11",
         "source-map": "^0.5.0",
@@ -114,16 +114,17 @@
       }
     },
     "@babel/helper-create-class-features-plugin": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.3.2.tgz",
-      "integrity": "sha512-tdW8+V8ceh2US4GsYdNVNoohq5uVwOf9k6krjwW4E1lINcHgttnWcNqgdoessn12dAy8QkbezlbQh2nXISNY+A==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.3.4.tgz",
+      "integrity": "sha512-uFpzw6L2omjibjxa8VGZsJUPL5wJH0zzGKpoz0ccBkzIa6C8kWNUbiBmQ0rgOKWlHJ6qzmfa6lTiGchiV8SC+g==",
       "dev": true,
       "requires": {
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-member-expression-to-functions": "^7.0.0",
         "@babel/helper-optimise-call-expression": "^7.0.0",
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.2.3"
+        "@babel/helper-replace-supers": "^7.3.4",
+        "@babel/helper-split-export-declaration": "^7.0.0"
       }
     },
     "@babel/helper-define-map": {
@@ -246,15 +247,15 @@
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.2.3.tgz",
-      "integrity": "sha512-GyieIznGUfPXPWu0yLS6U55Mz67AZD9cUk0BfirOWlPrXlBcan9Gz+vHGz+cPfuoweZSnPzPIm67VtQM0OWZbA==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.3.4.tgz",
+      "integrity": "sha512-pvObL9WVf2ADs+ePg0jrqlhHoxRXlOa+SHRHzAXIz2xkYuOHfGl+fKxPMaS4Fq+uje8JQPobnertBBvyrWnQ1A==",
       "dev": true,
       "requires": {
         "@babel/helper-member-expression-to-functions": "^7.0.0",
         "@babel/helper-optimise-call-expression": "^7.0.0",
-        "@babel/traverse": "^7.2.3",
-        "@babel/types": "^7.0.0"
+        "@babel/traverse": "^7.3.4",
+        "@babel/types": "^7.3.4"
       }
     },
     "@babel/helper-simple-access": {
@@ -311,9 +312,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.3.tgz",
-      "integrity": "sha512-xsH1CJoln2r74hR+y7cg2B5JCPaTh+Hd+EbBRk9nWGSNspuo6krjhX0Om6RnRQuIvFq8wVXCLKH3kwKDYhanSg==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.4.tgz",
+      "integrity": "sha512-tXZCqWtlOOP4wgCp6RjRvLmfuhnqTLy9VHwRochJBCP2nDm27JnnuFEnXFASVyQNHk36jD1tAammsCEEqgscIQ==",
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
@@ -328,12 +329,12 @@
       }
     },
     "@babel/plugin-proposal-class-properties": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.3.3.tgz",
-      "integrity": "sha512-XO9eeU1/UwGPM8L+TjnQCykuVcXqaO5J1bkRPIygqZ/A2L1xVMJ9aZXrY31c0U4H2/LHKL4lbFQLsxktSrc/Ng==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.3.4.tgz",
+      "integrity": "sha512-lUf8D3HLs4yYlAo8zjuneLvfxN7qfKv1Yzbj5vjqaqMJxgJA3Ipwp4VUJ+OrOdz53Wbww6ahwB8UhB2HQyLotA==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.3.0",
+        "@babel/helper-create-class-features-plugin": "^7.3.4",
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
@@ -359,9 +360,9 @@
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.3.2.tgz",
-      "integrity": "sha512-DjeMS+J2+lpANkYLLO+m6GjoTMygYglKmRe6cDTbFv3L9i6mmiE8fe6B8MtCSLZpVXscD5kn7s6SgtHrDoBWoA==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.3.4.tgz",
+      "integrity": "sha512-j7VQmbbkA+qrzNqbKHrBsW3ddFnOeva6wzSe/zB7T+xaxGc+RCpwo44wCmRixAIGRoIpmVgvzFzNJqQcO3/9RA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -462,9 +463,9 @@
       }
     },
     "@babel/plugin-transform-async-to-generator": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.2.0.tgz",
-      "integrity": "sha512-CEHzg4g5UraReozI9D4fblBYABs7IM6UerAVG7EJVrTLC5keh00aEuLUT+O40+mJCEzaXkYfTCUKIyeDfMOFFQ==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.3.4.tgz",
+      "integrity": "sha512-Y7nCzv2fw/jEZ9f678MuKdMo99MFDJMT/PvD9LisrR5JDFcJH6vYeH6RnjVt3p5tceyGRvTtEN0VOlU+rgHZjA==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
@@ -482,19 +483,19 @@
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.2.0.tgz",
-      "integrity": "sha512-vDTgf19ZEV6mx35yiPJe4fS02mPQUUcBNwWQSZFXSzTSbsJFQvHt7DqyS3LK8oOWALFOsJ+8bbqBgkirZteD5Q==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.3.4.tgz",
+      "integrity": "sha512-blRr2O8IOZLAOJklXLV4WhcEzpYafYQKSGT3+R26lWG41u/FODJuBggehtOwilVAcFu393v3OFj+HmaE6tVjhA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "lodash": "^4.17.10"
+        "lodash": "^4.17.11"
       }
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.3.3.tgz",
-      "integrity": "sha512-n0CLbsg7KOXsMF4tSTLCApNMoXk0wOPb0DYfsOO1e7SfIb9gOyfbpKI2MZ+AXfqvlfzq2qsflJ1nEns48Caf2w==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.3.4.tgz",
+      "integrity": "sha512-J9fAvCFBkXEvBimgYxCjvaVDzL6thk0j0dBvCeZmIUDBwyt+nv6HfbImsSrWsYXfDNDivyANgJlFXDUWRTZBuA==",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
@@ -502,7 +503,7 @@
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-optimise-call-expression": "^7.0.0",
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.1.0",
+        "@babel/helper-replace-supers": "^7.3.4",
         "@babel/helper-split-export-declaration": "^7.0.0",
         "globals": "^11.1.0"
       }
@@ -605,9 +606,9 @@
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.2.0.tgz",
-      "integrity": "sha512-aYJwpAhoK9a+1+O625WIjvMY11wkB/ok0WClVwmeo3mCjcNRjt+/8gHWrB5i+00mUju0gWsBkQnPpdvQ7PImmQ==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.3.4.tgz",
+      "integrity": "sha512-VZ4+jlGOF36S7TjKs8g4ojp4MEI+ebCQZdswWb/T9I4X84j8OtFAyjXjt/M16iIm5RIZn0UMQgg/VgIwo/87vw==",
       "dev": true,
       "requires": {
         "@babel/helper-hoist-variables": "^7.0.0",
@@ -664,18 +665,18 @@
       }
     },
     "@babel/plugin-transform-regenerator": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0.tgz",
-      "integrity": "sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.3.4.tgz",
+      "integrity": "sha512-hvJg8EReQvXT6G9H2MvNPXkv9zK36Vxa1+csAVTpE1J3j0zlHplw76uudEbJxgvqZzAq9Yh45FLD4pk5mKRFQA==",
       "dev": true,
       "requires": {
-        "regenerator-transform": "^0.13.3"
+        "regenerator-transform": "^0.13.4"
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.2.0.tgz",
-      "integrity": "sha512-jIgkljDdq4RYDnJyQsiWbdvGeei/0MOTtSHKO/rfbd/mXBxNpdlulMx49L0HQ4pug1fXannxoqCI+fYSle9eSw==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.3.4.tgz",
+      "integrity": "sha512-PaoARuztAdd5MgeVjAxnIDAIUet5KpogqaefQvPOmPYCxYoaPhautxDh3aO8a4xHsKgT/b9gSxR0BKK1MIewPA==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
@@ -752,16 +753,16 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.3.1.tgz",
-      "integrity": "sha512-FHKrD6Dxf30e8xgHQO0zJZpUPfVZg+Xwgz5/RdSWCbza9QLNk4Qbp40ctRoqDxml3O8RMzB1DU55SXeDG6PqHQ==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.3.4.tgz",
+      "integrity": "sha512-2mwqfYMK8weA0g0uBKOt4FE3iEodiHy9/CW0b+nWXcbL+pGzLx8ESYc+j9IIxr6LTDHWKgPm71i9smo02bw+gA==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
         "@babel/plugin-proposal-json-strings": "^7.2.0",
-        "@babel/plugin-proposal-object-rest-spread": "^7.3.1",
+        "@babel/plugin-proposal-object-rest-spread": "^7.3.4",
         "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
         "@babel/plugin-proposal-unicode-property-regex": "^7.2.0",
         "@babel/plugin-syntax-async-generators": "^7.2.0",
@@ -769,10 +770,10 @@
         "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
         "@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
         "@babel/plugin-transform-arrow-functions": "^7.2.0",
-        "@babel/plugin-transform-async-to-generator": "^7.2.0",
+        "@babel/plugin-transform-async-to-generator": "^7.3.4",
         "@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-        "@babel/plugin-transform-block-scoping": "^7.2.0",
-        "@babel/plugin-transform-classes": "^7.2.0",
+        "@babel/plugin-transform-block-scoping": "^7.3.4",
+        "@babel/plugin-transform-classes": "^7.3.4",
         "@babel/plugin-transform-computed-properties": "^7.2.0",
         "@babel/plugin-transform-destructuring": "^7.2.0",
         "@babel/plugin-transform-dotall-regex": "^7.2.0",
@@ -783,13 +784,13 @@
         "@babel/plugin-transform-literals": "^7.2.0",
         "@babel/plugin-transform-modules-amd": "^7.2.0",
         "@babel/plugin-transform-modules-commonjs": "^7.2.0",
-        "@babel/plugin-transform-modules-systemjs": "^7.2.0",
+        "@babel/plugin-transform-modules-systemjs": "^7.3.4",
         "@babel/plugin-transform-modules-umd": "^7.2.0",
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.3.0",
         "@babel/plugin-transform-new-target": "^7.0.0",
         "@babel/plugin-transform-object-super": "^7.2.0",
         "@babel/plugin-transform-parameters": "^7.2.0",
-        "@babel/plugin-transform-regenerator": "^7.0.0",
+        "@babel/plugin-transform-regenerator": "^7.3.4",
         "@babel/plugin-transform-shorthand-properties": "^7.2.0",
         "@babel/plugin-transform-spread": "^7.2.0",
         "@babel/plugin-transform-sticky-regex": "^7.2.0",
@@ -803,18 +804,18 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz",
-      "integrity": "sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.4.tgz",
+      "integrity": "sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.12.0"
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.3.1.tgz",
-      "integrity": "sha512-YpO13776h3e6Wy8dl2J8T9Qwlvopr+b4trCEhHE+yek6yIqV8sx6g3KozdHMbXeBpjosbPi+Ii5Z7X9oXFHUKA==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.3.4.tgz",
+      "integrity": "sha512-QwPuQE65kNxjsNKk34Rfgen2R5fk0J2So99SD45uXBp34QOfyz11SqVgJ4xvyCpnCIieSQ0X0hSSc9z/ymlJJw==",
       "dev": true,
       "requires": {
         "core-js": "^2.5.7",
@@ -833,20 +834,20 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.2.3.tgz",
-      "integrity": "sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.3.4.tgz",
+      "integrity": "sha512-TvTHKp6471OYEcE/91uWmhR6PrrYywQntCHSaZ8CM8Vmp+pjAusal4nGB2WCCQd0rvI7nOMKn9GnbcvTUz3/ZQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.2.2",
+        "@babel/generator": "^7.3.4",
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-split-export-declaration": "^7.0.0",
-        "@babel/parser": "^7.2.3",
-        "@babel/types": "^7.2.2",
+        "@babel/parser": "^7.3.4",
+        "@babel/types": "^7.3.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.10"
+        "lodash": "^4.17.11"
       },
       "dependencies": {
         "debug": {
@@ -861,9 +862,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.3.tgz",
-      "integrity": "sha512-2tACZ80Wg09UnPg5uGAOUvvInaqLk3l/IAhQzlxLQOIXacr6bMsra5SH6AWw/hIDRCSbCdHP2KzSOD+cT7TzMQ==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.4.tgz",
+      "integrity": "sha512-WEkp8MsLftM7O/ty580wAmZzN1nDmCACc5+jFzUt+GUFNNIi3LdRlueYz0YIlmJhlZx1QYDMZL5vdWCL0fNjFQ==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
@@ -999,9 +1000,9 @@
       }
     },
     "@sinonjs/samsam": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.1.1.tgz",
-      "integrity": "sha512-ILlwvQUwAiaVBzr3qz8oT1moM7AIUHqUc2UmEjQcH9lLe+E+BZPwUMuc9FFojMswRK4r96x5zDTTrowMLw/vuA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.2.0.tgz",
+      "integrity": "sha512-j5F1rScewLtx6pbTK0UAjA3jJj4RYiSKOix53YWv+Jzy/AZ69qHxUpU8fwVLjyKbEEud9QrLpv6Ggs7WqTimYw==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.0.2",
@@ -1049,33 +1050,6 @@
             "has-ansi": "^2.0.0",
             "strip-ansi": "^3.0.0",
             "supports-color": "^2.0.0"
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-              "dev": true
-            },
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^3.0.0"
-              }
-            }
           }
         },
         "strip-ansi": {
@@ -1172,9 +1146,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "11.9.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.9.4.tgz",
-      "integrity": "sha512-Zl8dGvAcEmadgs1tmSPcvwzO1YRsz38bVJQvH1RvRqSR9/5n61Q1ktcDL0ht3FXWR+ZpVmXVwN1LuH4Ax23NsA==",
+      "version": "11.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.9.5.tgz",
+      "integrity": "sha512-vVjM0SVzgaOUpflq4GYBvCpozes8OgIIS5gVXVka+OfK3hvnkC1i93U8WiY2OtNE4XUWyyy/86Kf6e0IHTQw1Q==",
       "dev": true
     },
     "@types/q": {
@@ -1499,9 +1473,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.0.tgz",
-          "integrity": "sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw==",
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+          "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
           "dev": true
         },
         "debug": {
@@ -1597,9 +1571,9 @@
       "dev": true
     },
     "@vue/component-compiler-utils": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@vue/component-compiler-utils/-/component-compiler-utils-2.5.2.tgz",
-      "integrity": "sha512-3exq9O89GXo9E+CGKzgURCbasG15FtFMs8QRrCUVWGaKue4Egpw41MHb3Avtikv1VykKfBq3FvAnf9Nx3sdVJg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@vue/component-compiler-utils/-/component-compiler-utils-2.6.0.tgz",
+      "integrity": "sha512-IHjxt7LsOFYc0DkTncB7OXJL7UzwOLPPQCfEUNyxL2qt+tF12THV+EO33O1G2Uk4feMSWua3iD39Itszx0f0bw==",
       "dev": true,
       "requires": {
         "consolidate": "^0.15.1",
@@ -1610,7 +1584,7 @@
         "postcss-selector-parser": "^5.0.0",
         "prettier": "1.16.3",
         "source-map": "~0.6.1",
-        "vue-template-es2015-compiler": "^1.8.2"
+        "vue-template-es2015-compiler": "^1.9.0"
       },
       "dependencies": {
         "lru-cache": {
@@ -1973,9 +1947,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.0.tgz",
-          "integrity": "sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw==",
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+          "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
           "dev": true
         }
       }
@@ -2040,9 +2014,9 @@
       }
     },
     "ajv": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz",
-      "integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
+      "version": "6.9.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.2.tgz",
+      "integrity": "sha512-4UFy0/LgDo7Oa/+wOAlj44tp9K78u38E5/359eSrqEp1Z5PdVfimCcs7SluXMP755RUQu6d2b4AvF0R1C9RZjg==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
@@ -2082,33 +2056,6 @@
       "dev": true,
       "requires": {
         "string-width": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
       }
     },
     "ansi-colors": {
@@ -2132,7 +2079,8 @@
     "ansi-regex": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-      "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w=="
+      "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+      "dev": true
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -2164,49 +2112,62 @@
       }
     },
     "apollo-cache": {
-      "version": "1.1.26",
-      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.1.26.tgz",
-      "integrity": "sha512-JKFHijwkhXpcQ3jOat+ctwiXyjDhQgy0p6GSaj7zG+or+ZSalPqUnPzFRgRwFLVbYxBKJgHCkWX+2VkxWTZzQQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.2.1.tgz",
+      "integrity": "sha512-nzFmep/oKlbzUuDyz6fS6aYhRmfpcHWqNkkA9Bbxwk18RD6LXC4eZkuE0gXRX0IibVBHNjYVK+Szi0Yied4SpQ==",
       "dev": true,
       "requires": {
-        "apollo-utilities": "^1.1.3",
+        "apollo-utilities": "^1.2.1",
         "tslib": "^1.9.3"
       }
     },
     "apollo-cache-control": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.5.1.tgz",
-      "integrity": "sha512-82hzX7/fFiu5dODLS8oGieEE4jLjMIhIkQ4JTsWj9drv8PZJltl0xqORtU2jA/FottjxfYab8+ebi3BgGPOaqw==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.5.2.tgz",
+      "integrity": "sha512-uehXDUrd3Qim+nzxqqN7XT1YTbNSyumW3/FY5BxbKZTI8d4oPG4eyVQKqaggooSjswKQnOoIQVes3+qg9tGAkw==",
       "dev": true,
       "requires": {
         "apollo-server-env": "2.2.0",
-        "graphql-extensions": "0.5.2"
+        "graphql-extensions": "0.5.4"
+      },
+      "dependencies": {
+        "graphql-extensions": {
+          "version": "0.5.4",
+          "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.5.4.tgz",
+          "integrity": "sha512-qLThJGVMqcItE7GDf/xX/E40m/aeqFheEKiR5bfra4q5eHxQKGjnIc20P9CVqjOn9I0FkEiU9ypOobfmIf7t6g==",
+          "dev": true,
+          "requires": {
+            "@apollographql/apollo-tools": "^0.3.3"
+          }
+        }
       }
     },
     "apollo-cache-inmemory": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.4.3.tgz",
-      "integrity": "sha512-p9KGtEZ9Mlb+FS0UEaxR8WvKOijYV0c+TXlhC/XZ3/ltYvP1zL3b1ozSOLGR9SawN2895Fc7QDV5nzPpihV0rA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.5.1.tgz",
+      "integrity": "sha512-D3bdpPmWfaKQkWy8lfwUg+K8OBITo3sx0BHLs1B/9vIdOIZ7JNCKq3EUcAgAfInomJUdN0QG1yOfi8M8hxkN1g==",
       "dev": true,
       "requires": {
-        "apollo-cache": "^1.1.26",
-        "apollo-utilities": "^1.1.3",
+        "apollo-cache": "^1.2.1",
+        "apollo-utilities": "^1.2.1",
         "optimism": "^0.6.9",
+        "ts-invariant": "^0.2.1",
         "tslib": "^1.9.3"
       }
     },
     "apollo-client": {
-      "version": "2.4.13",
-      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.4.13.tgz",
-      "integrity": "sha512-7mBdW/CW1qHB8Mj4EFAG3MTtbRc6S8aUUntUdrKfRWV1rZdWa0NovxsgVD/R4HZWZjRQ2UOM4ENsHdM5g1uXOQ==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.5.1.tgz",
+      "integrity": "sha512-MNcQKiqLHdGmNJ0rZ0NXaHrToXapJgS/5kPk0FygXt+/FmDCdzqcujI7OPxEC6e9Yw5S/8dIvOXcRNuOMElHkA==",
       "dev": true,
       "requires": {
         "@types/zen-observable": "^0.8.0",
-        "apollo-cache": "1.1.26",
+        "apollo-cache": "1.2.1",
         "apollo-link": "^1.0.0",
         "apollo-link-dedup": "^1.0.0",
-        "apollo-utilities": "1.1.3",
+        "apollo-utilities": "1.2.1",
         "symbol-observable": "^1.0.2",
+        "ts-invariant": "^0.2.1",
         "tslib": "^1.9.3",
         "zen-observable": "^0.8.0"
       }
@@ -2222,17 +2183,17 @@
       }
     },
     "apollo-engine-reporting": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-1.0.2.tgz",
-      "integrity": "sha512-g6JkO5WaMuqXfn3WoZMQyyFzpxfHsw/f7P7XTHSEqTSd/M4uk7/uih/xcqmgBGt4ET30KbaGFz2l4FJzO06A5w==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-1.0.7.tgz",
+      "integrity": "sha512-mFsXvd+1/o5jSa9tI2RoXYGcvCLcwwcfLwchjSTxqUd4ViB8RbqYKynzEZ+Omji7PBRM0azioBm43f7PSsQPqA==",
       "dev": true,
       "requires": {
         "apollo-engine-reporting-protobuf": "0.2.1",
         "apollo-graphql": "^0.1.0",
-        "apollo-server-core": "2.4.2",
+        "apollo-server-core": "2.4.8",
         "apollo-server-env": "2.2.0",
         "async-retry": "^1.2.1",
-        "graphql-extensions": "0.5.2"
+        "graphql-extensions": "0.5.7"
       }
     },
     "apollo-engine-reporting-protobuf": {
@@ -2346,24 +2307,24 @@
       }
     },
     "apollo-server-core": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.4.2.tgz",
-      "integrity": "sha512-IOWhqjjI1sH38sj7ycjke0dXXEgaqOkb2hDpLBTSiVWKBIqFfo4gchWK5wcWW9jReDpf/+G2wogH+UvONs2ejg==",
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.4.8.tgz",
+      "integrity": "sha512-N+5UOzHhMOnHizEiArJtNvEe/cGhSHQyTn5tlU4RJ36FDBJ/WlYZfPbGDMLISSUCJ6t+aP8GLL4Mnudt9d2PDQ==",
       "dev": true,
       "requires": {
         "@apollographql/apollo-tools": "^0.3.3",
         "@apollographql/graphql-playground-html": "^1.6.6",
         "@types/ws": "^6.0.0",
-        "apollo-cache-control": "0.5.1",
+        "apollo-cache-control": "0.5.2",
         "apollo-datasource": "0.3.1",
-        "apollo-engine-reporting": "1.0.2",
+        "apollo-engine-reporting": "1.0.7",
         "apollo-server-caching": "0.3.1",
         "apollo-server-env": "2.2.0",
-        "apollo-server-errors": "2.2.0",
-        "apollo-server-plugin-base": "0.3.2",
-        "apollo-tracing": "0.5.1",
+        "apollo-server-errors": "2.2.1",
+        "apollo-server-plugin-base": "0.3.7",
+        "apollo-tracing": "0.5.2",
         "fast-json-stable-stringify": "^2.0.0",
-        "graphql-extensions": "0.5.2",
+        "graphql-extensions": "0.5.7",
         "graphql-subscriptions": "^1.0.0",
         "graphql-tag": "^2.9.2",
         "graphql-tools": "^4.0.0",
@@ -2384,15 +2345,15 @@
       }
     },
     "apollo-server-errors": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.2.0.tgz",
-      "integrity": "sha512-gV9EZG2tovFtT1cLuCTavnJu2DaKxnXPRNGSTo+SDI6IAk6cdzyW0Gje5N2+3LybI0Wq5KAbW6VLei31S4MWmg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.2.1.tgz",
+      "integrity": "sha512-wY/YE3iJVMYC+WYIf8QODBjIP4jhI+oc7kiYo9mrz7LdYPKAgxr/he+NteGcqn/0Ea9K5/ZFTGJDbEstSMeP8g==",
       "dev": true
     },
     "apollo-server-express": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.4.2.tgz",
-      "integrity": "sha512-Q5/unCAi6a2dT39LQaIiLC1d8O4fmBDU2CrRhVhPWP8I344xPgNOcrs7MsNN7Ecb56UGbgDKxBoWowFG65ulKw==",
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.4.8.tgz",
+      "integrity": "sha512-i60l32mfVe33jnKDPNYgUKUKu4Al0xEm2HLOSMgtJ9Wbpe/MbOx5X8M5F27fnHYdM+G5XfAErsakAyRGnQJ48Q==",
       "dev": true,
       "requires": {
         "@apollographql/graphql-playground-html": "^1.6.6",
@@ -2401,7 +2362,7 @@
         "@types/cors": "^2.8.4",
         "@types/express": "4.16.1",
         "accepts": "^1.3.5",
-        "apollo-server-core": "2.4.2",
+        "apollo-server-core": "2.4.8",
         "body-parser": "^1.18.3",
         "cors": "^2.8.4",
         "graphql-subscriptions": "^1.0.0",
@@ -2410,19 +2371,30 @@
       }
     },
     "apollo-server-plugin-base": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.3.2.tgz",
-      "integrity": "sha512-yzXrkVSPBoux2uPgbTGROGh7W0axRWopMZM+KT9aF9H/+yMCwtt0EhGOGyNUDMOFA4rT3z+cLVvYuZr1rSQWcg==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.3.7.tgz",
+      "integrity": "sha512-hW1jaLKf9qNOxMTwRq2CSqz3eqXsZuEiCc8/mmEtOciiVBq1GMtxFf19oIYM9HQuPvQU2RWpns1VrYN59L3vbg==",
       "dev": true
     },
     "apollo-tracing": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.5.1.tgz",
-      "integrity": "sha512-5gb8OWzkGaJFsmQdyMyZnOjcq6weMTkqJSGj0hfR7uX99X4SBFAzZV4nTeK4z0XkXO2I12xSTJoS4gxbFjgeaA==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.5.2.tgz",
+      "integrity": "sha512-2FdwRvPIq9uuF6OzONroXep6VBGqzHOkP6LlcFQe7SdwxfRP+SD/ycHNSC1acVg2b8d+am9Kzqg2vV54UpOIKA==",
       "dev": true,
       "requires": {
         "apollo-server-env": "2.2.0",
-        "graphql-extensions": "0.5.2"
+        "graphql-extensions": "0.5.4"
+      },
+      "dependencies": {
+        "graphql-extensions": {
+          "version": "0.5.4",
+          "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.5.4.tgz",
+          "integrity": "sha512-qLThJGVMqcItE7GDf/xX/E40m/aeqFheEKiR5bfra4q5eHxQKGjnIc20P9CVqjOn9I0FkEiU9ypOobfmIf7t6g==",
+          "dev": true,
+          "requires": {
+            "@apollographql/apollo-tools": "^0.3.3"
+          }
+        }
       }
     },
     "apollo-upload-client": {
@@ -2437,12 +2409,13 @@
       }
     },
     "apollo-utilities": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.1.3.tgz",
-      "integrity": "sha512-pF9abhiClX5gfj/WFWZh8DiI33nOLGxRhXH9ZMquaM1V8bhq1WLFPt2QjShWH3kGQVeIGUK+FQefnhe+ZaaAYg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.2.1.tgz",
+      "integrity": "sha512-Zv8Udp9XTSFiN8oyXOjf6PMHepD4yxxReLsl6dPUy5Ths7jti3nmlBzZUOxuTWRwZn0MoclqL7RQ5UEJN8MAxg==",
       "dev": true,
       "requires": {
         "fast-json-stable-stringify": "^2.0.0",
+        "ts-invariant": "^0.2.1",
         "tslib": "^1.9.3"
       }
     },
@@ -2685,13 +2658,13 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "9.4.8",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.4.8.tgz",
-      "integrity": "sha512-DIhd0KMi9Nql3oJkJ2HCeOVihrXFPtWXc6ckwaUNwliDOt9OGr0fk8vV8jCLWXnZc1EXvQ2uLUzGpcPxFAQHEQ==",
+      "version": "9.4.9",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.4.9.tgz",
+      "integrity": "sha512-OyUl7KvbGBoFQbGQu51hMywz1aaVeud/6uX8r1R1DNcqFvqGUUy6+BDHnAZE8s5t5JyEObaSw+O1DpAdjAmLuw==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.4.1",
-        "caniuse-lite": "^1.0.30000938",
+        "browserslist": "^4.4.2",
+        "caniuse-lite": "^1.0.30000939",
         "normalize-range": "^0.1.2",
         "num2fraction": "^1.2.2",
         "postcss": "^7.0.14",
@@ -3131,33 +3104,6 @@
         "string-width": "^2.0.0",
         "term-size": "^1.2.0",
         "widest-line": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
       }
     },
     "brace-expansion": {
@@ -3289,14 +3235,14 @@
       }
     },
     "browserslist": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.4.1.tgz",
-      "integrity": "sha512-pEBxEXg7JwaakBXjATYw/D1YZh4QUSCX/Mnd/wnqSRPPSi1U39iDhDoKGoBUcraKdxDlrYqJxSI5nNvD+dWP2A==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.4.2.tgz",
+      "integrity": "sha512-ISS/AIAiHERJ3d45Fz0AVYKkgcy+F/eJHzKEvv1j0wwKGKD9T3BrwKr/5g45L+Y4XIK5PlTqefHciRFcfE1Jxg==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30000929",
-        "electron-to-chromium": "^1.3.103",
-        "node-releases": "^1.1.3"
+        "caniuse-lite": "^1.0.30000939",
+        "electron-to-chromium": "^1.3.113",
+        "node-releases": "^1.1.8"
       }
     },
     "buffer": {
@@ -3534,9 +3480,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000938",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000938.tgz",
-      "integrity": "sha512-ekW8NQ3/FvokviDxhdKLZZAx7PptXNwxKgXtnR5y+PR3hckwuP3yJ1Ir+4/c97dsHNqtAyfKUGdw8P4EYzBNgw==",
+      "version": "1.0.30000939",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000939.tgz",
+      "integrity": "sha512-oXB23ImDJOgQpGjRv1tCtzAvJr4/OvrHi5SO2vUgB0g0xpdZZoA/BxfImiWfdwoYdUTtQrPsXsvYU/dmCSM8gg==",
       "dev": true
     },
     "capture-stack-trace": {
@@ -3865,7 +3811,8 @@
     "ci-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
+      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
+      "dev": true
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -4046,16 +3993,6 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -4162,9 +4099,9 @@
       }
     },
     "colors": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
       "dev": true
     },
     "combined-stream": {
@@ -4283,16 +4220,9 @@
       "dev": true
     },
     "consola": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-2.4.1.tgz",
-      "integrity": "sha512-j6bIzpmyRGY2TDZVkAi3DM95CgC8hWx1A7AiJdyn4X5gls1bbpXIMpn3p8QsfaNu+ycNLXP+2DwKb47FXjw1ww==",
-      "requires": {
-        "chalk": "^2.4.2",
-        "dayjs": "^1.8.3",
-        "figures": "^2.0.0",
-        "std-env": "^2.2.1",
-        "string-width": "^3.0.0"
-      }
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-2.5.6.tgz",
+      "integrity": "sha512-DN0j6ewiNWkT09G3ZoyyzN3pSYrjxWcx49+mHu+oDI5dvW5vzmyuzYsqGS79+yQserH9ymJQbGzeqUejfssr8w=="
     },
     "console-browserify": {
       "version": "1.1.0",
@@ -5333,11 +5263,6 @@
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
     },
-    "dayjs": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.6.tgz",
-      "integrity": "sha512-NLhaSS1/wWLRFy0Kn/VmsAExqll2zxRUPmPbqJoeMKQrFxG+RT94VMSE+cVljB6A76/zZkR0Xub4ihTHQ5HgGg=="
-    },
     "de-indent": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
@@ -5501,13 +5426,12 @@
       "dev": true
     },
     "default-gateway": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-3.1.0.tgz",
-      "integrity": "sha512-MRhxv1cqdpKZh93zMFBkXcZfr2QFasrDlxjGa+M22Hv9EBmdWCccFe03KqSnkPLpYXlFhrR152kDX99S//3/Xw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.1.2.tgz",
+      "integrity": "sha512-xhJUAp3u02JsBGovj0V6B6uYhKCUOmiNc8xGmReUwGu77NmvcpxPVB0pCielxMFumO7CmXBG02XjM8HB97k8Hw==",
       "dev": true,
       "requires": {
         "execa": "^1.0.0",
-        "idb-connector": "^1.1.8",
         "ip-regex": "^2.1.0"
       }
     },
@@ -5804,9 +5728,9 @@
       }
     },
     "domhandler": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
-      "integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
       "dev": true,
       "requires": {
         "domelementtype": "1"
@@ -5970,11 +5894,6 @@
         "minimalistic-crypto-utils": "^1.0.0"
       }
     },
-    "emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
-    },
     "emojis-list": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
@@ -6010,8 +5929,7 @@
     "entities": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-      "dev": true
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
     "envinfo": {
       "version": "6.0.1",
@@ -6314,17 +6232,6 @@
           "requires": {
             "pseudomap": "^1.0.2",
             "yallist": "^2.1.2"
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -6681,9 +6588,9 @@
       "dev": true
     },
     "esm": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.5.tgz",
-      "integrity": "sha512-rukU6Nd3agbHQCJWV4rrlZxqpbO3ix8qhUxK1BhKALGS2E465O0BFwgCOqJjNnYfO/I2MwpUBmPsW8DXoe8tcA==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.7.tgz",
+      "integrity": "sha512-zsyD5gO8CY9dpK3IrdC4WHtvtHGXEFOpYA4zB+6p+Kygf3vv/6kF3YMEQLOArwKPPNvKt8gjI8UYhQW8bXM/YQ==",
       "dev": true
     },
     "espree": {
@@ -7160,6 +7067,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
       }
@@ -7462,9 +7370,9 @@
       }
     },
     "fs-capacitor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fs-capacitor/-/fs-capacitor-2.0.0.tgz",
-      "integrity": "sha512-CIJZpxbVWhO+qyODeCR55Q+6vj0p2oL8DAWd/DZi3Ev+25PimUoScw07K0fPgluaH3lFoqNvwW13BDYfHWFQJw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fs-capacitor/-/fs-capacitor-2.0.1.tgz",
+      "integrity": "sha512-kyV2oaG1/pu9NPosfGACmBym6okgzyg6hEtA5LSUq0dGpGLe278MVfMwVnSHDA/OBcTCHkPNqWL9eIwbPN6dDg==",
       "dev": true
     },
     "fs-constants": {
@@ -8454,19 +8362,19 @@
       }
     },
     "graphql-anywhere": {
-      "version": "4.1.28",
-      "resolved": "https://registry.npmjs.org/graphql-anywhere/-/graphql-anywhere-4.1.28.tgz",
-      "integrity": "sha512-NtLN0qmu2AasvZ31kwWte1UOw1mYRbfuSICbcVTshA2S5/BNZ7IVMl0X4wA2HPHc3mxN6rvrU4rS3+/Is2QsVw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/graphql-anywhere/-/graphql-anywhere-4.2.1.tgz",
+      "integrity": "sha512-4zlzTFzixGXtIYjX7BiXQOGhQ5yQVohj/EKNxUHUTAR7lHnCmrXU17gGtZ+108l9TkoHNfc33ieJ9U8trnHE1w==",
       "dev": true,
       "requires": {
-        "apollo-utilities": "^1.1.3",
+        "apollo-utilities": "^1.2.1",
         "tslib": "^1.9.3"
       }
     },
     "graphql-extensions": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.5.2.tgz",
-      "integrity": "sha512-D/FAvjYEZ8GM3vfALxRvItozy5iLUfzyoauE2lli+0OuUBCAZDLP0fgqeTFK93NnQX/XSjBVGhcuDWBB7JesEw==",
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.5.7.tgz",
+      "integrity": "sha512-HrU6APE1PiehZ46scMB3S5DezSeCATd8v+e4mmg2bqszMyCFkmAnmK6hR1b5VjHxhzt5/FX21x1WsXfqF4FwdQ==",
       "dev": true,
       "requires": {
         "@apollographql/apollo-tools": "^0.3.3"
@@ -8691,9 +8599,9 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "9.14.2",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.14.2.tgz",
-      "integrity": "sha512-Nc6YNECYpxyJABGYJAyw7dBAYbXEuIzwzkqoJnwbc1nIpCiN+3ioYf0XrBnLiyyG0JLuJhpPtt2iTSbXiKLoyA==",
+      "version": "9.15.6",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.6.tgz",
+      "integrity": "sha512-zozTAWM1D6sozHo8kqhfYgsac+B+q0PmsjXeyDrYIHHcBN0zTVT66+s2GW1GZv7DbyaROdLXKdabwS/WqPyIdQ==",
       "dev": true
     },
     "hmac-drbg": {
@@ -8714,9 +8622,9 @@
       "dev": true
     },
     "homedir-polyfill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
-      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
       "dev": true,
       "requires": {
         "parse-passwd": "^1.0.0"
@@ -8869,49 +8777,29 @@
       }
     },
     "htmlparser2": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
-      "integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
       "dev": true,
       "requires": {
-        "domelementtype": "1",
-        "domhandler": "2.1",
-        "domutils": "1.1",
-        "readable-stream": "1.0"
+        "domelementtype": "^1.3.1",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.1.1"
       },
       "dependencies": {
-        "domutils": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
-          "integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
-          "dev": true,
-          "requires": {
-            "domelementtype": "1"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
         "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
+          "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
         }
       }
     },
@@ -9007,12 +8895,6 @@
         "union": "~0.4.3"
       },
       "dependencies": {
-        "colors": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
-          "dev": true
-        },
         "opener": {
           "version": "1.4.3",
           "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
@@ -9104,535 +8986,6 @@
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
-      }
-    },
-    "idb-connector": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/idb-connector/-/idb-connector-1.1.8.tgz",
-      "integrity": "sha512-x+NIYJYmBnmFSbALM0GniG6idlEx3z+wnWqe+nKn948+sjY3TRzMmdG2ZqcBrlV/AsOTl3CidCIgdqRnxL1jiA==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "node-addon-api": "^1.2.0",
-        "node-pre-gyp": "^0.11.0"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "aproba": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "chownr": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "debug": {
-          "version": "2.6.9",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "detect-libc": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "fs-minipass": {
-          "version": "1.2.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "iconv-lite": {
-          "version": "0.4.24",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        },
-        "ignore-walk": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minimatch": "^3.0.4"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true
-        },
-        "minipass": {
-          "version": "2.3.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "needle": {
-          "version": "2.2.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "^2.1.2",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
-          }
-        },
-        "node-pre-gyp": {
-          "version": "0.11.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.1",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.2.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
-          }
-        },
-        "npm-bundled": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "npm-packlist": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "^0.6.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "semver": {
-          "version": "5.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "4.4.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "wide-align": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "^1.0.2 || 2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "yallist": {
-          "version": "3.0.3",
-          "bundled": true,
           "dev": true
         }
       }
@@ -9816,44 +9169,15 @@
         "string-width": "^2.1.0",
         "strip-ansi": "^5.0.0",
         "through": "^2.3.6"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^3.0.0"
-              }
-            }
-          }
-        }
       }
     },
     "internal-ip": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.0.0.tgz",
-      "integrity": "sha512-3Raw3cuBScBi7iQzisDbmG0KE/FyTYNYmBO34D9CCao3Exa7s4Eqxe3cQMDNuhTtKvG/zlYCXB4GBhxH2uARLg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.2.0.tgz",
+      "integrity": "sha512-ZY8Rk+hlvFeuMmG5uH1MXhhdeMntmIaxaInvAmzMq/SHV8rv4Kh+6GiQNNDQd0wZFrcO+FiTBo8lui/osKOyJw==",
       "dev": true,
       "requires": {
-        "default-gateway": "^3.1.0",
+        "default-gateway": "^4.0.1",
         "ipaddr.js": "^1.9.0"
       },
       "dependencies": {
@@ -10063,7 +9387,8 @@
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
     },
     "is-glob": {
       "version": "4.0.0",
@@ -10384,9 +9709,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
+      "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -10433,9 +9758,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.0.tgz",
-          "integrity": "sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw==",
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+          "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
           "dev": true
         },
         "tough-cookie": {
@@ -10453,8 +9778,7 @@
     "jsdom-global": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-3.0.2.tgz",
-      "integrity": "sha1-a9KZwTsMRiay2iwDk81DhdYGrLk=",
-      "dev": true
+      "integrity": "sha1-a9KZwTsMRiay2iwDk81DhdYGrLk="
     },
     "jsesc": {
       "version": "2.5.2",
@@ -10604,7 +9928,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.1.0.tgz",
       "integrity": "sha512-4REs8/062kV2DSHxNfq5183zrqXMl7WP0WzABH9IeJI+NLm429FgE1PDecltYfnOoFDFlZGh2T8PfZn0r+GTRg==",
-      "dev": true,
       "requires": {
         "uc.micro": "^1.0.1"
       }
@@ -11096,7 +10419,6 @@
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
       "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
-      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "entities": "~1.1.1",
@@ -11108,8 +10430,7 @@
     "markdown-it-anchor": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.0.2.tgz",
-      "integrity": "sha512-AFM/woBI8QDJMS/9+MmsBMT5/AR+ImfOsunQZTZhzcTmna3rIzAzbOh5E0l6mlFM/i9666BpUtkqQ9bS7WApCg==",
-      "dev": true
+      "integrity": "sha512-AFM/woBI8QDJMS/9+MmsBMT5/AR+ImfOsunQZTZhzcTmna3rIzAzbOh5E0l6mlFM/i9666BpUtkqQ9bS7WApCg=="
     },
     "md5.js": {
       "version": "1.3.5",
@@ -11131,8 +10452,7 @@
     "mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
-      "dev": true
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -11949,13 +11269,6 @@
         "lower-case": "^1.1.1"
       }
     },
-    "node-addon-api": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.6.2.tgz",
-      "integrity": "sha512-479Bjw9nTE5DdBSZZWprFryHGjUaQC31y1wHo19We/k0BZlrmhqQitWoUL0cD8+scljCbIUL+E58oRDEakdGGA==",
-      "dev": true,
-      "optional": true
-    },
     "node-fetch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
@@ -12310,9 +11623,9 @@
       "optional": true
     },
     "nwsapi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.0.tgz",
-      "integrity": "sha512-ZG3bLAvdHmhIjaQ/Db1qvBxsGvFMLIRpQszyqbg31VJ53UP++uZX1/gf3Ut96pdwN9AuDwlMqIYLm0UPCdUeHg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.1.tgz",
+      "integrity": "sha512-T5GaA1J/d34AC8mkrFD2O0DR17kwJ702ZOtJOsS8RpbsQZVOC2/xYFb1i/cw+xdM54JIlMuojjDOYct8GIWtwg==",
       "dev": true
     },
     "oauth-sign": {
@@ -12456,9 +11769,9 @@
       }
     },
     "on-headers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
-      "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
       "dev": true
     },
     "once": {
@@ -13769,9 +13082,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.12.26",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.26.tgz",
-          "integrity": "sha512-nMRqS+mL1TOnIJrL6LKJcNZPB8V3eTfRo9FQA2b5gDvrHurC8XbSA86KNe0dShlEL7ReWJv/OU9NL7Z0dnqWTg==",
+          "version": "10.12.27",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.27.tgz",
+          "integrity": "sha512-e9wgeY6gaY21on3ve0xAjgBVjGDWq/xUteK0ujsE53bUoxycMkqfnkUgMt6ffZtykZ5X12Mg3T7Pw4TRCObDKg==",
           "dev": true
         }
       }
@@ -14209,9 +13522,9 @@
       "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
     },
     "regenerator-transform": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.3.tgz",
-      "integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.4.tgz",
+      "integrity": "sha512-T0QMBjK3J0MtxjPmdIMXm72Wvj2Abb0Bd4HADdfijwMdoIsyQZ6fWC7kDFhk2YinBBEMZDL7Y7wh0J1sGx3S4A==",
       "dev": true,
       "requires": {
         "private": "^0.1.6"
@@ -14314,14 +13627,14 @@
       "dev": true
     },
     "renderkid": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.2.tgz",
-      "integrity": "sha512-FsygIxevi1jSiPY9h7vZmBFUbAOcbYm9UwyiLNdVsLRs/5We9Ob5NMPbGYUTWiLq5L+ezlVdE0A8bbME5CWTpg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.3.tgz",
+      "integrity": "sha512-z8CLQp7EZBPCwCnncgf9C4XAi3WR0dv+uWu/PjIyhhAb5d6IJ/QZqlHFprHeKT+59//V6BNUsLbvN8+2LarxGA==",
       "dev": true,
       "requires": {
         "css-select": "^1.1.0",
-        "dom-converter": "~0.2",
-        "htmlparser2": "~3.3.0",
+        "dom-converter": "^0.2",
+        "htmlparser2": "^3.3.0",
         "strip-ansi": "^3.0.0",
         "utila": "^0.4.0"
       },
@@ -14562,9 +13875,9 @@
       }
     },
     "rss-parser": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/rss-parser/-/rss-parser-3.6.2.tgz",
-      "integrity": "sha512-xXaMG7Zsj2+t16X+mysd419TpD2UQZifXwTo6Ks9GnUgF8GezPb3LVnh8BuCRm9V9Ty2gC0FRSvBJi8Ks2lfpg==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/rss-parser/-/rss-parser-3.6.3.tgz",
+      "integrity": "sha512-HASaMXqkUUw7mS+Sz780ml3Da3dG4ddIA3FRyXE8ae1KIiiDxG+jzrsNk/bpK1zDrDKe2WztjfQ5MRF323Kg3g==",
       "dev": true,
       "requires": {
         "entities": "^1.1.1",
@@ -14865,9 +14178,9 @@
       "dev": true
     },
     "saxes": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.6.tgz",
-      "integrity": "sha512-LAYs+lChg1v5uKNzPtsgTxSS5hLo8aIhSMCJt1WMpefAxm3D1RTpMwSpb6ebdL31cubiLTnhokVktBW+cv9Y9w==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.9.tgz",
+      "integrity": "sha512-FZeKhJglhJHk7eWG5YM0z46VHmI3KJpMBAQm3xa9meDvd+wevB5GuBB0wc0exPInZiBBHqi00DbS8AcvCGCFMw==",
       "dev": true,
       "requires": {
         "xmlchars": "^1.3.1"
@@ -15239,14 +14552,14 @@
       }
     },
     "sinon": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.2.4.tgz",
-      "integrity": "sha512-FGlcfrkiBRfaEIKRw8s/9mk4nP4AMGswvKFixLo+AzsOhskjaBCHAHGLMd8pCJpQGS+9ZI71px6qoQUyvADeyA==",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.2.5.tgz",
+      "integrity": "sha512-1c2KK6g5NQr9XNYCEcUbeFtBpKZD1FXEw0VX7gNhWUBtkchguT2lNdS7XmS7y64OpQWfSNeeV/f8py3NNcQ63Q==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.3.0",
         "@sinonjs/formatio": "^3.1.0",
-        "@sinonjs/samsam": "^3.1.1",
+        "@sinonjs/samsam": "^3.2.0",
         "diff": "^3.5.0",
         "lolex": "^3.1.0",
         "nise": "^1.4.10",
@@ -15690,14 +15003,6 @@
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
       "dev": true
     },
-    "std-env": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-2.2.1.tgz",
-      "integrity": "sha512-IjYQUinA3lg5re/YMlwlfhqNRTzMZMqE+pezevdcTaHceqx8ngEi1alX9nNCk9Sc81fy1fLDeQoaCzeiW1yBOQ==",
-      "requires": {
-        "ci-info": "^1.6.0"
-      }
-    },
     "stdout-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.1.tgz",
@@ -15768,13 +15073,30 @@
       "dev": true
     },
     "string-width": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.0.0.tgz",
-      "integrity": "sha512-rr8CUxBbvOZDUvc5lNIJ+OC1nPVpz+Siw9VBtUjB9b6jZehZLFt0JMCZzShFHIsI8cbhm0EsNIfWJMFV3cu3Ew==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
       "requires": {
-        "emoji-regex": "^7.0.1",
         "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.0.0"
+        "strip-ansi": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
       }
     },
     "string.prototype.padend": {
@@ -15812,6 +15134,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
       "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+      "dev": true,
       "requires": {
         "ansi-regex": "^4.0.0"
       }
@@ -15921,23 +15244,23 @@
       "dev": true
     },
     "svgo": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.1.1.tgz",
-      "integrity": "sha512-GBkJbnTuFpM4jFbiERHDWhZc/S/kpHToqmZag3aEBjPYK44JAN2QBjvrGIxLOoCyMZjuFQIfTO2eJd8uwLY/9g==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.2.0.tgz",
+      "integrity": "sha512-xBfxJxfk4UeVN8asec9jNxHiv3UAMv/ujwBWGYvQhhMb2u3YTGKkiybPcLFDLq7GLLWE9wa73e0/m8L5nTzQbw==",
       "dev": true,
       "requires": {
-        "coa": "~2.0.1",
-        "colors": "~1.1.2",
+        "chalk": "^2.4.1",
+        "coa": "^2.0.2",
         "css-select": "^2.0.0",
-        "css-select-base-adapter": "~0.1.0",
+        "css-select-base-adapter": "^0.1.1",
         "css-tree": "1.0.0-alpha.28",
         "css-url-regex": "^1.1.0",
-        "csso": "^3.5.0",
+        "csso": "^3.5.1",
         "js-yaml": "^3.12.0",
         "mkdirp": "~0.5.1",
-        "object.values": "^1.0.4",
+        "object.values": "^1.1.0",
         "sax": "~1.2.4",
-        "stable": "~0.1.6",
+        "stable": "^0.1.8",
         "unquote": "~1.1.1",
         "util.promisify": "~1.0.0"
       }
@@ -15989,13 +15312,6 @@
           "dev": true,
           "optional": true
         },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true,
-          "optional": true
-        },
         "co": {
           "version": "4.6.0",
           "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -16016,27 +15332,6 @@
           "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
           "dev": true,
           "optional": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
         }
       }
     },
@@ -16220,9 +15515,9 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.2.tgz",
-      "integrity": "sha512-1DMkTk286BzmfylAvLXwpJrI7dWa5BnFmscV/2dCr8+c56egFcbaeFAl7+sujAjdmpLam21XRdhA4oifLyiWWg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.3.tgz",
+      "integrity": "sha512-GOK7q85oAb/5kE12fMuLdn2btOS9OBZn4VsecpHDywoUC/jLhSAKOiYo0ezx7ss2EXPMzyEWFoE0s1WLE+4+oA==",
       "dev": true,
       "requires": {
         "cacache": "^11.0.2",
@@ -16490,6 +15785,15 @@
       "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==",
       "dev": true
     },
+    "ts-invariant": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.2.1.tgz",
+      "integrity": "sha512-Z/JSxzVmhTo50I+LKagEISFJW3pvPCqsMWLamCTX8Kr3N5aMrnGOqcflbe5hLUzwjvgPfnLzQtHZv0yWQ+FIHg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
     "ts-node": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
@@ -16567,8 +15871,7 @@
     "uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
-      "dev": true
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
     },
     "uglify-js": {
       "version": "3.4.9",
@@ -17043,9 +16346,9 @@
       }
     },
     "vue": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.6.tgz",
-      "integrity": "sha512-Y2DdOZD8sxApS+iUlwv1v8U1qN41kq6Kw45lM6nVZKhygeWA49q7VCCXkjXqeDBXgurrKWkYQ9cJeEJwAq0b9Q=="
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.7.tgz",
+      "integrity": "sha512-g7ADfQ82QU+j6F/bVDioVQf2ccIMYLuR4E8ev+RsDBlmwRkhGO3HhgF4PF9vpwjdPpxyb1zzLur2nQ2oIMAMEg=="
     },
     "vue-cli-plugin-apollo": {
       "version": "0.19.1",
@@ -17171,9 +16474,9 @@
       "integrity": "sha512-pvLc+H+x2prwBj/uSEIITyxjz/7ZUVVK8uYbrYMmhDvMXnzh9OvQvVEwcOSBQjsubd4Eq41/CSJaWzy4hemMNQ=="
     },
     "vue-hot-reload-api": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.2.tgz",
-      "integrity": "sha512-NpznMQoe/DzMG7nJjPkJKT7FdEn9xXfnntG7POfTmqnSaza97ylaBf1luZDh4IgV+vgUoR//id5pf8Ru+Ym+0g==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.3.tgz",
+      "integrity": "sha512-KmvZVtmM26BQOMK1rwUZsrqxEGeKiYSZGA7SNWE6uExx8UX/cj9hq2MRV/wWC3Cq6AoeDGk57rL9YMFRel/q+g==",
       "dev": true
     },
     "vue-json-tree": {
@@ -17222,9 +16525,9 @@
       }
     },
     "vue-template-compiler": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.6.tgz",
-      "integrity": "sha512-OakxDGyrmMQViCjkakQFbDZlG0NibiOzpLauOfyCUVRQc9yPmTqpiz9nF0VeA+dFkXegetw0E5x65BFhhLXO0A==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.7.tgz",
+      "integrity": "sha512-ZjxJLr6Lw2gj6aQGKwBWTxVNNd28/qggIdwvr5ushrUHUvqgbHD0xusOVP2yRxT4pX3wRIJ2LfxjgFT41dEtoQ==",
       "dev": true,
       "requires": {
         "de-indent": "^1.0.2",
@@ -17232,9 +16535,9 @@
       }
     },
     "vue-template-es2015-compiler": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.8.2.tgz",
-      "integrity": "sha512-cliV19VHLJqFUYbz/XeWXe5CO6guzwd0yrrqqp0bmjlMP3ZZULY7fu8RTC4+3lmHwo6ESVDHFDsvjB15hcR5IA==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
+      "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
     },
     "w3c-hr-time": {
@@ -17393,9 +16696,9 @@
       }
     },
     "webpack-dev-server": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.2.0.tgz",
-      "integrity": "sha512-CUGPLQsUBVKa/qkZl1MMo8krm30bsOHAP8jtn78gUICpT+sR3esN4Zb0TSBzOEEQJF0zHNEbwx5GHInkqcmlsA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.2.1.tgz",
+      "integrity": "sha512-sjuE4mnmx6JOh9kvSbPYw3u/6uxCLHNWfhWaIPwcXWsvWOPN+nc5baq4i9jui3oOBRXGonK9+OI0jVkaz6/rCw==",
       "dev": true,
       "requires": {
         "ansi-html": "0.0.7",
@@ -17409,7 +16712,7 @@
         "html-entities": "^1.2.0",
         "http-proxy-middleware": "^0.19.1",
         "import-local": "^2.0.0",
-        "internal-ip": "^4.0.0",
+        "internal-ip": "^4.2.0",
         "ip": "^1.1.5",
         "killable": "^1.0.0",
         "loglevel": "^1.4.1",
@@ -17506,33 +16809,6 @@
             "ajv": "^6.1.0",
             "ajv-errors": "^1.0.0",
             "ajv-keywords": "^3.1.0"
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-              "dev": true
-            },
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^3.0.0"
-              }
-            }
           }
         },
         "strip-ansi": {
@@ -17710,33 +16986,6 @@
       "dev": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
       }
     },
     "widest-line": {
@@ -17746,33 +16995,6 @@
       "dev": true,
       "requires": {
         "string-width": "^2.1.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
       }
     },
     "wordwrap": {
@@ -17969,12 +17191,6 @@
         "yargs-parser": "^9.0.2"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
         "find-up": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -18017,25 +17233,6 @@
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
           "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
           "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
         },
         "y18n": {
           "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monarch-ui",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "private": true,
   "scripts": {
     "clean": "rm -rf dist/",
@@ -10,7 +10,8 @@
     "build": "node_modules/.bin/vue-cli-service build && cp dist/index.html dist/404.html",
     "buildandserve": "npm run build && (cd dist/ && ln -s . monarch-ui) && http-server -c-1 dist/",
     "analyze": "BUILD=analyze node_modules/.bin/vue-cli-service build",
-    "lint": "node_modules/.bin/vue-cli-service lint",
+    "lint": "node_modules/.bin/vue-cli-service lint --no-fix",
+    "lintfix": "node_modules/.bin/vue-cli-service lint --fix",
     "test": "npm run test:unit && npm run test:e2e",
     "test:unit": "node_modules/.bin/vue-cli-service test:unit --require tests/unit/pre-setup.js",
     "test:e2e": "node_modules/.bin/vue-cli-service test:e2e",
@@ -23,15 +24,21 @@
     "bootstrap": "4.3.1",
     "bootstrap-vue": "^2.0.0-rc.13",
     "d3": "^5.9.1",
+    "d3-axis": "^1.0.12",
+    "d3-scale": "^2.2.2",
+    "d3-selection": "^1.4.0",
     "file-saver": "^2.0.1",
     "font-awesome": "^4.7.0",
     "genomefeaturecomponent": "^0.2.7",
-    "js-yaml": "^3.12.1",
+    "js-yaml": "^3.12.2",
+    "jsdom-global": "^3.0.2",
     "lodash": "^4.17.11",
+    "markdown-it": "^8.4.2",
+    "markdown-it-anchor": "^5.0.2",
     "phenogrid": "^1.4.0",
     "register-service-worker": "^1.6.2",
     "underscore": "^1.9.1",
-    "vue": "^2.6.6",
+    "vue": "^2.6.7",
     "vue-form-wizard": "^0.8.4",
     "vue-json-tree": "^0.3.3",
     "vue-router": "^3.0.2"
@@ -53,14 +60,12 @@
     "eslint-plugin-import": "^2.16.0",
     "html-loader": "^0.5.5",
     "http-server": "^0.11.1",
-    "markdown-it": "^8.4.2",
-    "markdown-it-anchor": "^5.0.2",
     "node-sass": "^4.11.0",
     "sass-loader": "^7.1.0",
-    "sinon": "^7.2.4",
+    "sinon": "^7.2.5",
     "vue-cli-plugin-bootstrap-vue": "^0.1.0",
     "vue-cli-plugin-webpack-bundle-analyzer": "^1.2.0",
     "vue-markdown-loader": "^2.4.1",
-    "vue-template-compiler": "^2.6.6"
+    "vue-template-compiler": "^2.6.7"
   }
 }

--- a/src/components/LocalNav.vue
+++ b/src/components/LocalNav.vue
@@ -2,49 +2,46 @@
   <div>
     <div v-if="!dataFetched">Loading Related Terms ...</div>
     <div v-else>
-      <div class="row border-bottom py-2">
-        <div class="col-4"><h5>Parent Terms</h5></div>
-        <div class="col-4"><h5>Equivalent Terms</h5></div>
-        <div class="col-4"><h5>Child Terms</h5></div>
+      <div class="row border-bottom">
+        <div class="col-4"><h6>Parent Terms</h6></div>
+        <div class="col-4"><h6>Equivalent Terms</h6></div>
+        <div class="col-4"><h6>Child Terms</h6></div>
       </div>
 
-      <div class="row py-2">
+      <div
+        v-for="(row, rowIndex) in classRows"
+        :key="rowIndex"
+        class="row">
         <div
-          v-for="superclass in superclasses"
-          :key="superclass.id"
-          class="col-4"
-        >
+          class="col-4">
           <button
-            class="p-1 m-1 btn btn-sm btn-info"
-            @click="emitSelection(superclass.label, superclass.id)"
+            v-if="row.superclass"
+            class="m-1 btn btn-sm btn-info"
+            @click="emitSelection(row.superclass.label, row.superclass.id)"
           >
-            {{ superclass.label }} <br> ({{ superclass.id }})
+            {{ row.superclass.label }} <br> ({{ row.superclass.id }})
           </button>
         </div>
 
         <div
-          v-for="sibling in equivalentClasses"
-          :key="sibling.id"
-          class="col-4"
-        >
+          class="col-4">
           <button
-            class="p-1 m-1 btn btn-sm btn-info"
-            @click="emitSelection(sibling.label, sibling.id)"
+            v-if="row.equivalentClass"
+            class="m-1 btn btn-sm btn-info"
+            @click="emitSelection(row.equivalentClass.label, row.equivalentClass.id)"
           >
-            {{ sibling.label }} <br> ({{ sibling.id }})
+            {{ row.equivalentClass.label }} <br> ({{ row.equivalentClass.id }})
           </button>
         </div>
 
         <div
-          v-for="subclass in subclasses"
-          :key="subclass.id"
-          class="col-4"
-        >
+          class="col-4">
           <button
-            class="p-1 m-1 btn btn-sm btn-info"
-            @click="emitSelection(subclass.label, subclass.id)"
+            v-if="row.subclass"
+            class="m-1 btn btn-sm btn-info"
+            @click="emitSelection(row.subclass.label, row.subclass.id)"
           >
-            {{ subclass.label }} <br> ({{ subclass.id }})
+            {{ row.subclass.label }} <br> ({{ row.subclass.id }})
           </button>
         </div>
       </div>
@@ -60,7 +57,12 @@ export default {
     anchorId: {
       type: String,
       required: true
-    }
+    },
+    anchorType: {
+      type: String,
+      required: false,
+      default: 'phenotype'
+    },
   },
   data() {
     return {
@@ -69,8 +71,14 @@ export default {
       familyData: [],
       subclasses: [],
       siblings: [],
+      classRows: [],
       dataFetched: false
     };
+  },
+  watch: {
+    anchorId() {
+      this.getCurieRelationships();
+    },
   },
   mounted() {
     this.getCurieRelationships();
@@ -79,7 +87,7 @@ export default {
     async getCurieRelationships() {
       const that = this;
       try {
-        const searchResponse = await BL.getNodeSummary(this.anchorId, 'phenotype');
+        const searchResponse = await BL.getNodeSummary(this.anchorId, this.anchorType);
         this.familyData = searchResponse;
         await this.sortRelationships();
         this.dataFetched = true;
@@ -121,6 +129,20 @@ export default {
         id: c,
         label: nodeLabelMap[c]
       }));
+
+      const maxRows = Math.max(
+        this.superclasses.length,
+        this.subclasses.length,
+        this.equivalentClasses.length
+      );
+      this.classRows = [];
+      for (let cindex = 0; cindex < maxRows; ++cindex) {
+        this.classRows.push({
+          superclass: this.superclasses[cindex],
+          subclass: this.subclasses[cindex],
+          equivalentClass: this.equivalentClasses[cindex],
+        });
+      }
     }
   }
 };

--- a/src/components/MonarchAutocomplete.vue
+++ b/src/components/MonarchAutocomplete.vue
@@ -204,10 +204,12 @@ export default {
     definedCategories: {
       type: Array,
       required: false,
+      default: null,
     },
     allowedPrefixes: {
       type: Array,
       required: false,
+      default: null,
     },
     dynamicPlaceholder: {
       type: String,

--- a/src/components/MonarchAutocomplete.vue
+++ b/src/components/MonarchAutocomplete.vue
@@ -27,7 +27,7 @@
         >
           <div class="form-group">
             <b-form-checkbox-group
-              v-model="selected"
+              v-model="categories"
               :options="options"
               plain
               stacked/>
@@ -220,7 +220,7 @@ export default {
   data() {
     return {
       destroying: false,
-      selected: [],
+      categories: [],
       exampleSearches,
       options: [
 
@@ -239,7 +239,7 @@ export default {
         this.open = false;
       }
     },
-    selected(newValue) {
+    categories(newValue) {
       if (!this.definedCategories) {
         this.suggestions = [];
         if (this.value.length > 0) {
@@ -256,7 +256,7 @@ export default {
           value: elem,
         });
       });
-      this.definedCategories.forEach(elem => this.selected.push(elem));
+      this.definedCategories.forEach(elem => this.categories.push(elem));
     }
     else {
       this.options = [
@@ -296,8 +296,7 @@ export default {
     ),
     async fetchData() {
       try {
-        const selected = this.selected;
-        const searchResponse = await BL.getSearchTermSuggestions(this.value, selected, this.allowedPrefixes);
+        const searchResponse = await BL.getSearchTermSuggestions(this.value, this.categories, this.allowedPrefixes);
         this.suggestions = [];
         this.current = -1;
         searchResponse.docs.forEach((elem) => {
@@ -409,9 +408,9 @@ export default {
       return null;
     },
     useExample(searchString, category) {
-      this.selected = [];
+      this.categories = [];
       if (category) {
-        this.selected.push(category);
+        this.categories.push(category);
       }
       this.value = searchString;
     }

--- a/src/components/PhenotypesTable.vue
+++ b/src/components/PhenotypesTable.vue
@@ -79,32 +79,37 @@ export default {
     geneList: {
       type: Array,
       required: false,
+      default: null,
     }
   },
 
 
   data() {
     return {
-      test: {  combinedScore: 65,
-        hitId: "MONDO:0015999",
-        hitLabel: "primary pigmented nodular adrenocortical disease",
-        mostInformativeIc: "10.16",
-        mostInformativeId: "HP:0001065",
-        mostInformativeLabel: "Striae distensae",
-        mostInformativeLink: "/phenotype/HP:0001065",
-        otherMatchIc: "3.67",
-        otherMatchId: "MP:0001533",
-        otherMatchLabel: "abnormal skeleton physiology",
-        otherMatchLink: "/phenotype/MP:0001533"},
+      test: {
+        combinedScore: 65,
+        hitId: 'MONDO:0015999',
+        hitLabel: 'primary pigmented nodular adrenocortical disease',
+        mostInformativeIc: '10.16',
+        mostInformativeId: 'HP:0001065',
+        mostInformativeLabel: 'Striae distensae',
+        mostInformativeLink: '/phenotype/HP:0001065',
+        otherMatchIc: '3.67',
+        otherMatchId: 'MP:0001533',
+        otherMatchLabel: 'abnormal skeleton physiology',
+        otherMatchLink: '/phenotype/MP:0001533'
+      },
       dataFetched: false,
       rowsPerPage: 10,
       currentPage: 1,
       fields: [
-        { key: 'hitLabel',
+        {
+          key: 'hitLabel',
           label: 'Match Label',
           sortable: true
         },
-        { key: 'hitId',
+        {
+          key: 'hitId',
           label: 'Match Identifier',
           sortable: true
         },
@@ -113,7 +118,8 @@ export default {
           key: 'combinedScore',
           sortable: true
         },
-        { key: 'mostInformativeLabel',
+        {
+          key: 'mostInformativeLabel',
           label: 'Most Informative Phenotype',
           sortable: true
         },
@@ -121,7 +127,7 @@ export default {
           key: 'mostInformativeId',
           label: 'Most Informative Id',
           sortable: true,
-        },{
+        }, {
           key: 'mostInformativeIc',
           label: 'Most Informative IC Score',
           sortable: true,

--- a/src/main.js
+++ b/src/main.js
@@ -39,4 +39,4 @@ debugSpinnerLink.addEventListener('click', () => {
   debugLogos[1].classList.toggle('rotate');
 });
 
-window.MonarchUIVersion = '0.0.6';
+window.MonarchUIVersion = '0.0.7';

--- a/src/views/AnalyzePhenotypes.vue
+++ b/src/views/AnalyzePhenotypes.vue
@@ -57,9 +57,10 @@
         <div class="p-3">
           <h4>Phenotype Profile</h4>
           <div class="flex-container">
+
             <div
               v-for="(phenotype, index) in phenotypes"
-              :key="phenotype.curie"
+              :key="index"
               class="m-1"
             >
               <div
@@ -67,8 +68,9 @@
                 role="group"
               >
                 <button
-                  v-b-modal="phenotype.curie"
+                  v-b-modal.phenotypeModal
                   class="btn btn-sm btn-info"
+                  @click="displayPhenotypeModal(phenotype)"
                 >
                   <strong>{{ phenotype.match }}</strong> | {{ phenotype.curie }}
                 </button>
@@ -80,26 +82,6 @@
                   <strong>x</strong>
                 </button>
               </div>
-              <b-modal
-                :id="phenotype.curie"
-                v-model="modalShow"
-                size="lg"
-                title="phenotype.label"
-              >
-                <div
-                  slot="modal-title"
-                  class="w-100"
-                >
-                  <strong>{{ phenotype.match }}</strong> | {{ phenotype.curie }}
-                </div>
-                <div
-                  v-if="modalShow">
-                  <local-nav
-                    :anchor-id="phenotype.curie"
-                    @interface="handleReplacePhenotype"
-                  />
-                </div>
-              </b-modal>
             </div>
           </div>
         </div>
@@ -168,9 +150,10 @@
         <div class="p-3">
           <h4>Taxon Groups</h4>
           <div
+            v-for="group in selectedGroups"
+            :key="group.groupId"
             class="btn-group"
             role="group"
-            v-for="group in selectedGroups"
           >
             <div
               class="badge badge-info group-badge p-2"
@@ -209,8 +192,9 @@
                 role="group"
               >
                 <button
-                  v-b-modal="gene.curie"
+                  v-b-modal.geneModal
                   class="btn btn-sm btn-info"
+                  @click="displayGeneModal(gene)"
                 >
                   <strong>{{ gene.match }} </strong>({{ gene.curie }})
                 </button>
@@ -222,24 +206,7 @@
                   <strong>x</strong>
                 </button>
               </div>
-              <b-modal
-                :id="gene.curie"
-                size="lg"
-                title="gene.label"
-              >
-                <div
-                  slot="modal-title"
-                  class="w-100"
-                >
-                  {{ gene.match }} | {{ gene.curie }}
-                </div>
-                <div>
-                  <local-nav
-                    :anchor-id="gene.curie"
-                    @interface="handleReplaceGene"
-                  />
-                </div>
-              </b-modal>
+
             </div>
           </div>
         </div>
@@ -285,6 +252,52 @@
       </div>
       <div class="col-1"/>
     </div>
+
+
+    <b-modal
+      id="phenotypeModal"
+      v-model="phenotypeModal"
+      lazy
+      size="xl"
+      title="selectedPhenotype.label"
+    >
+      <div
+        slot="modal-title"
+        class="w-100"
+      >
+        <strong>{{ selectedPhenotype.match }}</strong> | {{ selectedPhenotype.curie }}
+      </div>
+      <div
+        v-if="phenotypeModal">
+        <local-nav
+          :anchor-id="selectedPhenotype.curie"
+          @interface="handleReplacePhenotype"
+        />
+      </div>
+    </b-modal>
+
+    <b-modal
+      id="geneModal"
+      v-model="geneModal"
+      lazy
+      size="xl"
+      title="selectedGene.label"
+    >
+      <div
+        slot="modal-title"
+        class="w-100"
+      >
+        {{ selectedGene.match }} | {{ selectedGene.curie }}
+      </div>
+      <div
+        v-if="geneModal">
+        <local-nav
+          :anchor-id="selectedGene.curie"
+          :anchor-type="'gene'"
+          @interface="handleReplaceGene"
+        />
+      </div>
+    </b-modal>
   </div>
 </template>
 
@@ -302,198 +315,6 @@ Vue.use(VueFormWizard);
 
 const findIndex = require('lodash/findIndex');
 
-function applyExampleData(vm) {
-  const phenogridExampleData = [
-    {
-      'id': 'HP:0000174',
-      'term': 'Abnormality of the palate'
-    },
-    {
-      'id': 'HP:0000194',
-      'term': 'Open mouth'
-    },
-    {
-      'id': 'HP:0000218',
-      'term': 'High palate'
-    },
-    {
-      'id': 'HP:0000238',
-      'term': 'Hydrocephalus'
-    },
-    {
-      'id': 'HP:0000244',
-      'term': 'Brachyturricephaly'
-    },
-    {
-      'id': 'HP:0000272',
-      'term': 'Malar flattening'
-    },
-    {
-      'id': 'HP:0000303',
-      'term': 'Mandibular prognathia'
-    },
-    {
-      'id': 'HP:0000316',
-      'term': 'Hypertelorism'
-    },
-    {
-      'id': 'HP:0000322',
-      'term': 'Short philtrum'
-    },
-    {
-      'id': 'HP:0000324',
-      'term': 'Facial asymmetry'
-    },
-    {
-      'id': 'HP:0000327',
-      'term': 'Hypoplasia of the maxilla'
-    },
-    {
-      'id': 'HP:0000348',
-      'term': 'High forehead'
-    },
-    {
-      'id': 'HP:0000431',
-      'term': 'Wide nasal bridge'
-    },
-    {
-      'id': 'HP:0000452',
-      'term': 'Choanal stenosis'
-    },
-    {
-      'id': 'HP:0000453',
-      'term': 'Choanal atresia'
-    },
-    {
-      'id': 'HP:0000470',
-      'term': 'Short neck'
-    },
-    {
-      'id': 'HP:0000486',
-      'term': 'Strabismus'
-    },
-    {
-      'id': 'HP:0000494',
-      'term': 'Downslanted palpebral fissures'
-    },
-    {
-      'id': 'HP:0000508',
-      'term': 'Ptosis'
-    },
-    {
-      'id': 'HP:0000586',
-      'term': 'Shallow orbits'
-    },
-    {
-      'id': 'HP:0000678',
-      'term': 'Dental crowding'
-    },
-    {
-      'id': 'HP:0001156',
-      'term': 'Brachydactyly syndrome'
-    },
-    {
-      'id': 'HP:0001249',
-      'term': 'Intellectual disability'
-    },
-    {
-      'id': 'HP:0002308',
-      'term': 'Arnold-Chiari malformation'
-    },
-    {
-      'id': 'HP:0002676',
-      'term': 'Cloverleaf skull'
-    },
-    {
-      'id': 'HP:0002780',
-      'term': 'Bronchomalacia'
-    },
-    {
-      'id': 'HP:0003041',
-      'term': 'Humeroradial synostosis'
-    },
-    {
-      'id': 'HP:0003070',
-      'term': 'Elbow ankylosis'
-    },
-    {
-      'id': 'HP:0003196',
-      'term': 'Short nose'
-    },
-    {
-      'id': 'HP:0003272',
-      'term': 'Abnormality of the hip bone'
-    },
-    {
-      'id': 'HP:0003307',
-      'term': 'Hyperlordosis'
-    },
-    {
-      'id': 'HP:0003795',
-      'term': 'Short middle phalanx of toe'
-    },
-    {
-      'id': 'HP:0004209',
-      'term': 'Clinodactyly of the 5th finger'
-    },
-    {
-      'id': 'HP:0004322',
-      'term': 'Short stature'
-    },
-    {
-      'id': 'HP:0004440',
-      'term': 'Coronal craniosynostosis'
-    },
-    {
-      'id': 'HP:0005048',
-      'term': 'Synostosis of carpal bones'
-    },
-    {
-      'id': 'HP:0005280',
-      'term': 'Depressed nasal bridge'
-    },
-    {
-      'id': 'HP:0005347',
-      'term': 'Cartilaginous trachea'
-    },
-    {
-      'id': 'HP:0006101',
-      'term': 'Finger syndactyly'
-    },
-    {
-      'id': 'HP:0006110',
-      'term': 'Shortening of all middle phalanges of the fingers'
-    },
-    {
-      'id': 'HP:0009602',
-      'term': 'Abnormality of thumb phalanx'
-    },
-    {
-      'id': 'HP:0009773',
-      'term': 'Symphalangism affecting the phalanges of the hand'
-    },
-    {
-      'id': 'HP:0010055',
-      'term': 'Broad hallux'
-    },
-    // {
-    //   'id': 'HP:0010669',
-    //   'term': 'Hypoplasia of the zygomatic bone'
-    // },
-    {
-      'id': 'HP:0011304',
-      'term': 'Broad thumb'
-    }
-  ];
-
-  vm.phenoCurieList = phenogridExampleData.map(function (s) {
-    return s.id;
-  }).join(',');
-  console.log(vm.phenoCurieList);
-
-  vm.selectedGroups = [vm.groupOptions[0].value, vm.groupOptions[1].value, vm.groupOptions[2].value];
-}
-
 export default {
   name: 'AnalyzePhenotypes',
   components: {
@@ -504,7 +325,10 @@ export default {
   },
   data() {
     return {
-      modalShow: false,
+      phenotypeModal: false,
+      selectedPhenotype: {},
+      geneModal: false,
+      selectedGene: {},
       acceptedPrefixes: ['MONDO', 'HP', 'NCBIGene', 'HGNC'],
       phenoSearchPH: 'search for phenotypes or disease',
       geneSearchPH: 'search for genes',
@@ -591,11 +415,18 @@ export default {
     }
   },
   async mounted() {
-    // applyExampleData(this);
-    // await this.generatePGDataFromPhenotypeList();
+    await this.applyExampleData();
   },
 
   methods: {
+    displayPhenotypeModal(item) {
+      this.selectedPhenotype = item;
+    },
+
+    displayGeneModal(item) {
+      this.selectedGene = item;
+    },
+
     async fetchLabel(curie, curieType) {
       const that = this;
       try {
@@ -606,7 +437,7 @@ export default {
             this.showGeneAlert = false;
           }
         }
-        if (curieType === 'gene') {
+        else if (curieType === 'gene') {
           this.convertGenes(searchResponse);
           if (searchResponse.status === 500) {
             this.showGeneAlert = true;
@@ -662,6 +493,7 @@ export default {
       });
       this.phenotypes.splice(replaceIndex, 1);
       this.phenotypes.push(payload);
+      this.selectedPhenotype = payload;
     },
     handleGenes(payload) {
       this.genes.push(payload);
@@ -672,6 +504,7 @@ export default {
       });
       this.genes.splice(replaceIndex, 1);
       this.genes.push(payload);
+      this.selectedGene = payload;
     },
     generatePhenogridData() {
       this.showPhenogrid = true;
@@ -690,10 +523,10 @@ export default {
       }));
       this.pgIndex += 1;
     },
-    geneListLookup() {
+    async geneListLookup() {
       this.genes = [];
-      this.geneCurieList.split(',').forEach((elem) => {
-        this.fetchLabel(`${this.geneCurieType}:${elem.trim()}`, 'gene');
+      this.geneCurieList.split(',').forEach(async (elem) => {
+        await this.fetchLabel(`${this.geneCurieType}:${elem.trim()}`, 'gene');
       });
     },
     async generatePGDataFromPhenotypeList() {
@@ -703,7 +536,7 @@ export default {
         const elemTrimmed = elem.trim();
         const prefix = elemTrimmed.split(':')[0];
         if (this.acceptedPrefixes.includes(prefix)) {
-          this.fetchLabel(elemTrimmed, 'phenotype');
+          await this.fetchLabel(elemTrimmed, 'phenotype');
         }
         else {
           this.rejectedPhenotypeCuries.push(elemTrimmed);
@@ -739,7 +572,204 @@ export default {
         curie: phenoData.id,
         match: phenoData.label
       });
-    }
+    },
+
+    async applyExampleData() {
+      const phenogridExampleData = [
+        {
+          'id': 'HP:0000174',
+          'term': 'Abnormality of the palate'
+        },
+        {
+          'id': 'HP:0000194',
+          'term': 'Open mouth'
+        },
+        {
+          'id': 'HP:0000218',
+          'term': 'High palate'
+        },
+        {
+          'id': 'HP:0000238',
+          'term': 'Hydrocephalus'
+        },
+        {
+          'id': 'HP:0000244',
+          'term': 'Brachyturricephaly'
+        },
+        {
+          'id': 'HP:0000272',
+          'term': 'Malar flattening'
+        },
+        {
+          'id': 'HP:0000303',
+          'term': 'Mandibular prognathia'
+        },
+        {
+          'id': 'HP:0000316',
+          'term': 'Hypertelorism'
+        },
+        {
+          'id': 'HP:0000322',
+          'term': 'Short philtrum'
+        },
+        {
+          'id': 'HP:0000324',
+          'term': 'Facial asymmetry'
+        },
+        {
+          'id': 'HP:0000327',
+          'term': 'Hypoplasia of the maxilla'
+        },
+        {
+          'id': 'HP:0000348',
+          'term': 'High forehead'
+        },
+        {
+          'id': 'HP:0000431',
+          'term': 'Wide nasal bridge'
+        },
+        {
+          'id': 'HP:0000452',
+          'term': 'Choanal stenosis'
+        },
+        {
+          'id': 'HP:0000453',
+          'term': 'Choanal atresia'
+        },
+        {
+          'id': 'HP:0000470',
+          'term': 'Short neck'
+        },
+        {
+          'id': 'HP:0000486',
+          'term': 'Strabismus'
+        },
+        {
+          'id': 'HP:0000494',
+          'term': 'Downslanted palpebral fissures'
+        },
+        {
+          'id': 'HP:0000508',
+          'term': 'Ptosis'
+        },
+        {
+          'id': 'HP:0000586',
+          'term': 'Shallow orbits'
+        },
+        {
+          'id': 'HP:0000678',
+          'term': 'Dental crowding'
+        },
+        {
+          'id': 'HP:0001156',
+          'term': 'Brachydactyly syndrome'
+        },
+        {
+          'id': 'HP:0001249',
+          'term': 'Intellectual disability'
+        },
+        {
+          'id': 'HP:0002308',
+          'term': 'Arnold-Chiari malformation'
+        },
+        {
+          'id': 'HP:0002676',
+          'term': 'Cloverleaf skull'
+        },
+        {
+          'id': 'HP:0002780',
+          'term': 'Bronchomalacia'
+        },
+        {
+          'id': 'HP:0003041',
+          'term': 'Humeroradial synostosis'
+        },
+        {
+          'id': 'HP:0003070',
+          'term': 'Elbow ankylosis'
+        },
+        {
+          'id': 'HP:0003196',
+          'term': 'Short nose'
+        },
+        {
+          'id': 'HP:0003272',
+          'term': 'Abnormality of the hip bone'
+        },
+        {
+          'id': 'HP:0003307',
+          'term': 'Hyperlordosis'
+        },
+        {
+          'id': 'HP:0003795',
+          'term': 'Short middle phalanx of toe'
+        },
+        {
+          'id': 'HP:0004209',
+          'term': 'Clinodactyly of the 5th finger'
+        },
+        {
+          'id': 'HP:0004322',
+          'term': 'Short stature'
+        },
+        {
+          'id': 'HP:0004440',
+          'term': 'Coronal craniosynostosis'
+        },
+        {
+          'id': 'HP:0005048',
+          'term': 'Synostosis of carpal bones'
+        },
+        {
+          'id': 'HP:0005280',
+          'term': 'Depressed nasal bridge'
+        },
+        {
+          'id': 'HP:0005347',
+          'term': 'Cartilaginous trachea'
+        },
+        {
+          'id': 'HP:0006101',
+          'term': 'Finger syndactyly'
+        },
+        {
+          'id': 'HP:0006110',
+          'term': 'Shortening of all middle phalanges of the fingers'
+        },
+        {
+          'id': 'HP:0009602',
+          'term': 'Abnormality of thumb phalanx'
+        },
+        {
+          'id': 'HP:0009773',
+          'term': 'Symphalangism affecting the phalanges of the hand'
+        },
+        {
+          'id': 'HP:0010055',
+          'term': 'Broad hallux'
+        },
+        {
+          'id': 'HP:0010669',
+          'term': 'Hypoplasia of the zygomatic bone'
+          // Monarch says this EquivalentTo HP:0000272: 'Malar flattening'
+        },
+        {
+          'id': 'HP:0011304',
+          'term': 'Broad thumb'
+        }
+      ];
+
+      this.phenoCurieList = phenogridExampleData.map(function getId(s) {
+        return s.id;
+      }).join(',');
+
+      this.geneCurieList = 'NCBIGene:3845,HGNC:2176';
+
+      this.selectedGroups = [this.groupOptions[0].value, this.groupOptions[1].value, this.groupOptions[2].value];
+
+      await this.generatePGDataFromPhenotypeList();
+      await this.generatePGDataFromGeneList();
+    },
   }
 };
 </script>

--- a/src/views/AnalyzePhenotypes.vue
+++ b/src/views/AnalyzePhenotypes.vue
@@ -415,7 +415,7 @@ export default {
     }
   },
   async mounted() {
-    await this.applyExampleData();
+    // await this.applyExampleData();
   },
 
   methods: {

--- a/tests/e2e/specs/disease.js
+++ b/tests/e2e/specs/disease.js
@@ -1,5 +1,5 @@
 module.exports = {
-  'Disease Node Tests': (browser) => {
+  'Marfan Syndrome - MONDO:0007947': (browser) => {
     browser
       .url(process.env.VUE_DEV_SERVER_URL + 'disease/MONDO:0007947')
       .waitForElementVisible('#app', 5000)
@@ -7,5 +7,16 @@ module.exports = {
       .assert.containsText('.node-description', 'disorder of the connective tissue')
       .assert.elementCount('.node-card', 6)
       .end();
-  }
+  },
+
+  'Troyer syndrome - MONDO:0010156': (browser) => {
+    browser
+      .url(process.env.VUE_DEV_SERVER_URL + 'disease/MONDO:0010156')
+      .waitForElementVisible('#app', 5000)
+      .waitForElementVisible('.node-content-section', 5000)
+      .assert.containsText('.node-description', 'which encodes the protein spartin')
+      .assert.elementCount('.node-card', 5)
+      .assert.containsText('.node-synonyms', 'spastic paraplegia')
+      .end();
+  },
 };

--- a/tests/unit/About.spec.js
+++ b/tests/unit/About.spec.js
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
+import axios from 'axios';
 import { shallowMountWithRouting } from './test-utils';
 import AboutMonarch from '@/views/AboutMonarch.md';
 import AboutTeam from '@/views/AboutTeam.md';
-import axios from 'axios';
 
 const teamResponse = {
   data:

--- a/tests/unit/test-utils.js
+++ b/tests/unit/test-utils.js
@@ -1,3 +1,5 @@
+/* eslint import/prefer-default-export: 0 */
+
 import { shallowMount } from '@vue/test-utils';
 
 export function shallowMountWithRouting(component, options) {


### PR DESCRIPTION
0.0.7
- Add another e2e test.
- Use BL 'development' which has the new shiny singular get_association_counts, as well as some other fixes.
- REALLY parallelize the BL calls to /graph and /bioentity. 0.0.6   prepped for this.
- Simplify Node.vue by eliminating the progress timer, which appears to   have been obviated over time.
- Eliminate the unnecessary has_gene_track state var in Node.vue.
- Simplify getNodeSummary, which doesn't need uri for LocalNav.vue (although really, all /bioentity funcs should return uri if possible.
- Calling the /identifier/prefixes/expand endpoint is stupid).
- Fixes many bugs in AnalyzePhenotypes.vue and LocalNav.vue.
- Improves layout of AP slightly
- Improves example used for debugging
- Fix some ESLint errors
- Change default for 'npm run lint' to '--nofix'
- Add an 'npm run lintfix' that uses '--fix'
