### PR TITLE
0.0.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "monarch-ui",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1166,9 +1166,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "11.11.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
-      "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==",
+      "version": "11.11.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.8.tgz",
+      "integrity": "sha512-87dYasmW2iLSYNTc3WU85taIQb1RBz6KK9w/Hnbkyu3n9xeNd0fbVaPoGMyX1ErGB8PaqNuCtYjpoI9aN6DoCg==",
       "dev": true
     },
     "@types/q": {
@@ -3539,9 +3539,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000951",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000951.tgz",
-      "integrity": "sha512-eRhP+nQ6YUkIcNQ6hnvdhMkdc7n3zadog0KXNRxAZTT2kHjUb1yGn71OrPhSn8MOvlX97g5CR97kGVj8fMsXWg==",
+      "version": "1.0.30000953",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000953.tgz",
+      "integrity": "sha512-2stdF/q5MZTDhQ6uC65HWbSgI9UMKbc7+HKvlwH5JBIslKoD/J9dvabP4J4Uiifu3NljbHj3iMpfYflLSNt09A==",
       "dev": true
     },
     "capture-stack-trace": {
@@ -9114,9 +9114,9 @@
       }
     },
     "ieee754": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
-      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
       "dev": true
     },
     "iferr": {
@@ -13212,9 +13212,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.14.3",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.3.tgz",
-          "integrity": "sha512-2lhc7S28vo8FwR3Jv3Ifyd77AxEsx+Nl9ajWiac6/eWuvZ84zPK4RE05pfqcn3acIzlZDpQj5F1rIKQZX3ptLQ==",
+          "version": "10.14.4",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.4.tgz",
+          "integrity": "sha512-DT25xX/YgyPKiHFOpNuANIQIVvYEwCWXgK2jYYwqgaMrYE6+tq+DtmMwlD3drl6DJbUwtlIDnn0d7tIn/EbXBg==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monarch-ui",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "private": true,
   "scripts": {
     "clean": "rm -rf dist/",

--- a/public/index.html
+++ b/public/index.html
@@ -5,11 +5,12 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
-    <title>Monarch Initiative UI</title>
+    <title>Monarch Initiative Explorer</title>
   </head>
 
 
-  <body>
+  <body
+    style="height: unset;">
     <noscript>
       <strong>Please enable JavaScript and reload this page to continue.</strong>
     </noscript>

--- a/src/api/BioLink.js
+++ b/src/api/BioLink.js
@@ -347,6 +347,29 @@ function getBiolinkAnnotation(cardType) {
 }
 
 
+function invertAssociationsIfNecessary(nodeType, cardType, response) {
+  let invert = false;
+
+  // Remove the apiServer restriction clause when
+  // https://github.com/biolink/biolink-api/pull/261
+  // is on production. 3/29/2019 DBK
+  if (nodeType === 'anatomy'
+     && apiServer === 'production') {
+    invert = true;
+  }
+
+  if (invert) {
+    console.log('invertAssociationsIfNecessary', nodeType, cardType);
+    response.associations.forEach((a) => {
+      // console.log(JSON.stringify(a, null, 2));
+      const tmp = a.subject;
+      a.subject = a.object;
+      a.object = tmp;
+    });
+  }
+}
+
+
 export async function getNodeAssociations(nodeType, nodeId, cardType, params) {
   const baseUrl = `${biolink}bioentity/`;
   const biolinkAnnotationSuffix = getBiolinkAnnotation(cardType);
@@ -354,6 +377,8 @@ export async function getNodeAssociations(nodeType, nodeId, cardType, params) {
   const url = `${baseUrl}${urlExtension}`;
 
   const response = await axios.get(url, { params });
+
+  invertAssociationsIfNecessary(nodeType, cardType, response.data);
 
   return response;
 }

--- a/src/api/MyGene.js
+++ b/src/api/MyGene.js
@@ -83,43 +83,63 @@ export async function getGeneDescription(geneId) {
 
     result = mygeneResponse.data;
 
-    if (result.hits.length > 0 && result.hits[0].genomic_pos) {
+    if (result.hits.length > 0) {
       const hit = result.hits[0];
-      // console.log('hit', hit);
-
       const symbol = hit.symbol;
-      const locationObj = hit.genomic_pos;
-      let taxid = hit.taxid;
-      if (locationObj) {
-        // sometimes data is not on the genomic position
-        if (!taxid) {
-          taxid = locationObj.taxid;
+
+      if (!hit.genomic_pos) {
+        console.log('getGeneDescription MyGene response missing hit.genomic_pos', mygeneResponse);
+      }
+      else {
+        const locationObj = hit.genomic_pos;
+        if (!locationObj) {
+          console.log('getGeneDescription MyGene response contains zero hit.genomic_pos, which is not currently supported by GenomeFeatureViewer', mygeneResponse);
         }
-        // use this mapping: http://docs.mygene.info/en/latest/doc/data.html#species
-        const thisSpecies = getSpeciesFromTaxId(taxid);
-        if (!thisSpecies) {
-          console.log('Species not found from mygene.info.  Not showing genome features.');
+        else if (locationObj.length > 1) {
+          //
+          // This is a hack to detect genes (e.g., HGNC:11180) who return an array of genomic_pos,
+          // rather than a single genomic_pos. The code below needs to be enhanced to deal with this
+          // case, and perhaps GenomeFeatureViewer needs adjusting too.
+          // I'm currently just detecting the situation, reporting it, and disabling the
+          // GenomeFeatureViewer when this occurs.
+          // Not all genes have this characteristic. For example, HGNC:11773 works fine.
+          //
+          console.log('getGeneDescription MyGene response contains more than one hit.genomic_pos, which is not currently supported by GenomeFeatureViewer', mygeneResponse);
+          result = null;
         }
         else {
-          const defaultTrackName = 'All Genes'; // this is the generic track name
-          const locationString = locationObj.chr + ':' + locationObj.start + '..' + locationObj.end;
-          const apolloServerPrefix = 'https://agr-apollo.berkeleybop.io/apollo/';
-          const externalUrl = 'http://jbrowse.alliancegenome.org/jbrowse/index.html?data=data/' + encodeURI(thisSpecies) + '&loc=' + encodeURI(locationString);
-          const trackDataPrefix = apolloServerPrefix + 'track/' + encodeURI(thisSpecies) + '/' + defaultTrackName + '/' + encodeURI(locationString) + '.json';
-          const trackDataWithHighlightURL = trackDataPrefix + '?name=' + symbol;
+          let taxid = hit.taxid;
 
-          // console.log('trackDataWithHighlight', trackDataWithHighlightURL);
-          const trackResponse = await axios.get(trackDataWithHighlightURL);
-          // console.log('trackResponse', trackResponse.data);
+          // sometimes data is not on the genomic position
+          if (!taxid) {
+            taxid = locationObj.taxid;
+          }
+          // use this mapping: http://docs.mygene.info/en/latest/doc/data.html#species
+          const thisSpecies = getSpeciesFromTaxId(taxid);
+          if (!thisSpecies) {
+            console.log('Species not found from mygene.info.  Not showing genome features.');
+          }
+          else {
+            const defaultTrackName = 'All Genes'; // this is the generic track name
+            const locationString = locationObj.chr + ':' + locationObj.start + '..' + locationObj.end;
+            const apolloServerPrefix = 'https://agr-apollo.berkeleybop.io/apollo/';
+            const externalUrl = 'http://jbrowse.alliancegenome.org/jbrowse/index.html?data=data/' + encodeURI(thisSpecies) + '&loc=' + encodeURI(locationString);
+            const trackDataPrefix = apolloServerPrefix + 'track/' + encodeURI(thisSpecies) + '/' + defaultTrackName + '/' + encodeURI(locationString) + '.json';
+            const trackDataWithHighlightURL = trackDataPrefix + '?name=' + symbol;
 
-          result.trackResponse = trackResponse.data;
-          result.externalURL = externalUrl;
+            // console.log('trackDataWithHighlight', trackDataWithHighlightURL);
+            const trackResponse = await axios.get(trackDataWithHighlightURL);
+            // console.log('trackResponse', trackResponse.data);
+
+            result.trackResponse = trackResponse.data;
+            result.externalURL = externalUrl;
+          }
         }
       }
     }
   }
   catch (e) {
-    console.log('mygene.info error', e.message);
+    console.log('MyGene.getGeneDescription error', e.message);
   }
 
   return result;

--- a/src/main.js
+++ b/src/main.js
@@ -39,4 +39,4 @@ debugSpinnerLink.addEventListener('click', () => {
   debugLogos[1].classList.toggle('rotate');
 });
 
-window.MonarchUIVersion = '0.0.9';
+window.MonarchUIVersion = '0.0.10';

--- a/src/views/Node.vue
+++ b/src/views/Node.vue
@@ -59,7 +59,7 @@
                 {{ nodeLabel }}
               </span>
               <span
-                v-if="node.taxon.id"
+                v-if="node.taxon && node.taxon.id"
                 class="node-label-taxon">
                 {{ node.taxon.label }} ({{ node.taxon.id }})
               </span>
@@ -596,7 +596,7 @@ export default {
 
       const hash = this.$router.currentRoute.hash;
       if (hash.length > 1) {
-        const cardType = hash.slice(1);
+        const cardType = hash.split('?')[0].slice(1);
         this.$nextTick((_) => {
           this.expandCard(cardType);
         });
@@ -628,12 +628,12 @@ export default {
         ]
       );
 
-
       if (this.nodeType === 'publication') {
         const entrezResult = await Entrez.getPublication(this.nodeId);
+
         this.entrezResult = entrezResult;
-        this.node.label = entrezResult.title;
-        this.node.iri = entrezResult.pubmedURL;
+        nodeSummary.label = entrezResult.title;
+        nodeSummary.iri = entrezResult.pubmedURL;
 
         let abstractEnhanced = this.entrezResult.abstract;
         abstractEnhanced = abstractEnhanced.replace(
@@ -753,17 +753,19 @@ div.container-cards .node-cards-section {
 }
 
 .title-bar .node-synonyms {
-  line-height: $line-height-compact;
+  line-height: 1.0em;
+  margin: 0;
 }
 
 .title-bar .synonym {
-  padding: 2px 10px 1px 2px;
+  padding: 0 2px;
+  margin: 0 15px 0 0;
   font-size: 0.9em;
-  background: white;
+  font-weight: 500;
 }
 
 .title-bar .node-label {
-  margin: 2px 5px 5px 2px;
+  margin: 2px;
 }
 
 .title-bar .node-label-label {


### PR DESCRIPTION
- Tighten up the synonyms area at the top of Node.vue so that they are
  more visible, more distinct, and take a little less vertical space.
- Fix regression where Entrez publication info wasn't displayed on
  Publication page.
- Ensure that cardType is detected properly from the URL hash, even if
  ?api=foo URL argument is used also.
- Disable exampleData debug code in AnalyzePhenotypes
- Better layout of AssocTable and Support.
- Eliminate use of Vue filters in favor of methods.
- Invert 'sense' of anatomy/gene associations when on production,
  because BL is backward. BL has been fixed for development and this
kludge can go away eventually.
- Fix MyGene.js/GenomeFeatureViewer and its handling of certain genes
  that cause a crash. Current fix is to detect the situation and return
no gene data. For example, HGNC:11180 exhibits this problem. The CORRECT
fix (@nathandunn) is to make GenomeFeatureViewer work with this gene.