### PR TITLE
0.0.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "monarch-ui",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -38,17 +38,17 @@
       }
     },
     "@babel/core": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.0.tgz",
-      "integrity": "sha512-Dzl7U0/T69DFOTwqz/FJdnOSWS57NpjNfCwMKHABr589Lg8uX1RrlBIJ7L5Dubt/xkLsx0xH5EBFzlBVes1ayA==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.3.tgz",
+      "integrity": "sha512-oDpASqKFlbspQfzAE7yaeTmdljSH2ADIvBlb0RwbStltTuWa0+7CCI1fYVINNv9saHPa1W7oaKeuNuKj+RQCvA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/generator": "^7.4.0",
-        "@babel/helpers": "^7.4.0",
-        "@babel/parser": "^7.4.0",
+        "@babel/helpers": "^7.4.3",
+        "@babel/parser": "^7.4.3",
         "@babel/template": "^7.4.0",
-        "@babel/traverse": "^7.4.0",
+        "@babel/traverse": "^7.4.3",
         "@babel/types": "^7.4.0",
         "convert-source-map": "^1.1.0",
         "debug": "^4.1.0",
@@ -114,9 +114,9 @@
       }
     },
     "@babel/helper-create-class-features-plugin": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.4.0.tgz",
-      "integrity": "sha512-2K8NohdOT7P6Vyp23QH4w2IleP8yG3UJsbRKwA4YP6H8fErcLkFuuEEqbF2/BYBKSNci/FWJiqm6R3VhM/QHgw==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.4.3.tgz",
+      "integrity": "sha512-UMl3TSpX11PuODYdWGrUeW6zFkdYhDn7wRLrOuNVM6f9L+S9CzmDXYyrp3MTHcwWjnzur1f/Op8A7iYZWya2Yg==",
       "dev": true,
       "requires": {
         "@babel/helper-function-name": "^7.1.0",
@@ -196,9 +196,9 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.2.2.tgz",
-      "integrity": "sha512-YRD7I6Wsv+IHuTPkAmAS4HhY0dkPobgLftHp0cRGZSdrRvmZY8rFvae/GVu3bD00qscuvK3WPHB3YdNpBXUqrA==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.4.3.tgz",
+      "integrity": "sha512-H88T9IySZW25anu5uqyaC1DaQre7ofM+joZtAaO2F8NBdFfupH0SZ4gKjgSFVcvtx/aAirqA9L9Clio2heYbZA==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
@@ -206,7 +206,7 @@
         "@babel/helper-split-export-declaration": "^7.0.0",
         "@babel/template": "^7.2.2",
         "@babel/types": "^7.2.2",
-        "lodash": "^4.17.10"
+        "lodash": "^4.17.11"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -225,12 +225,12 @@
       "dev": true
     },
     "@babel/helper-regex": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0.tgz",
-      "integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.3.tgz",
+      "integrity": "sha512-hnoq5u96pLCfgjXuj8ZLX3QQ+6nAulS+zSgi6HulUwFbEruRAKwbGLU5OvXkE14L8XW6XsQEKsIDfgthKLRAyA==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.10"
+        "lodash": "^4.17.11"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -290,13 +290,13 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.2.tgz",
-      "integrity": "sha512-gQR1eQeroDzFBikhrCccm5Gs2xBjZ57DNjGbqTaHo911IpmSxflOQWMAHPw/TXk8L3isv7s9lYzUkexOeTQUYg==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.3.tgz",
+      "integrity": "sha512-BMh7X0oZqb36CfyhvtbSmcWc3GXocfxv3yNsAEuM0l+fAqSO22rQrUpijr3oE/10jCTrB6/0b9kzmG4VetCj8Q==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.4.0",
-        "@babel/traverse": "^7.4.0",
+        "@babel/traverse": "^7.4.3",
         "@babel/types": "^7.4.0"
       }
     },
@@ -312,9 +312,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.2.tgz",
-      "integrity": "sha512-9fJTDipQFvlfSVdD/JBtkiY0br9BtfvW2R8wo6CX/Ej2eMuV0gWPk1M67Mt3eggQvBqYW1FCEk8BN7WvGm/g5g==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
+      "integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
@@ -360,9 +360,9 @@
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.0.tgz",
-      "integrity": "sha512-uTNi8pPYyUH2eWHyYWWSYJKwKg34hhgl4/dbejEjL+64OhbHjTX7wEVWMQl82tEmdDsGeu77+s8HHLS627h6OQ==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.3.tgz",
+      "integrity": "sha512-xC//6DNSSHVjq8O2ge0dyYlhshsH4T7XdCVoxbi5HzLYWfsC5ooFlJjrXk8RcAT+hjHAK9UjBXdylzSoDK3t4g==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -493,9 +493,9 @@
       }
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.0.tgz",
-      "integrity": "sha512-XGg1Mhbw4LDmrO9rSTNe+uI79tQPdGs0YASlxgweYRLZqo/EQktjaOV4tchL/UZbM0F+/94uOipmdNGoaGOEYg==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.3.tgz",
+      "integrity": "sha512-PUaIKyFUDtG6jF5DUJOfkBdwAS/kFFV3XFk7Nn0a6vR7ZT8jYw5cGtIlat77wcnd0C6ViGqo/wyNf4ZHytF/nQ==",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
@@ -518,23 +518,23 @@
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.0.tgz",
-      "integrity": "sha512-HySkoatyYTY3ZwLI8GGvkRWCFrjAGXUHur5sMecmCIdIharnlcWWivOqDJI76vvmVZfzwb6G08NREsrY96RhGQ==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.3.tgz",
+      "integrity": "sha512-rVTLLZpydDFDyN4qnXdzwoVpk1oaXHIvPEOkOLyr88o7oHxVc/LyrnDx+amuBWGOwUb7D1s/uLsKBNTx08htZg==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-dotall-regex": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.2.0.tgz",
-      "integrity": "sha512-sKxnyHfizweTgKZf7XsXu/CNupKhzijptfTM+bozonIuyVrLWVUvYjE2bhuSBML8VQeMxq4Mm63Q9qvcvUcciQ==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.3.tgz",
+      "integrity": "sha512-9Arc2I0AGynzXRR/oPdSALv3k0rM38IMFyto7kOCwb5F9sLUt2Ykdo3V9yUPR+Bgr4kb6bVEyLkPEiBhzcTeoA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.0.0",
-        "regexpu-core": "^4.1.3"
+        "@babel/helper-regex": "^7.4.3",
+        "regexpu-core": "^4.5.4"
       }
     },
     "@babel/plugin-transform-duplicate-keys": {
@@ -557,18 +557,18 @@
       }
     },
     "@babel/plugin-transform-for-of": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.0.tgz",
-      "integrity": "sha512-vWdfCEYLlYSxbsKj5lGtzA49K3KANtb8qCPQ1em07txJzsBwY+cKJzBHizj5fl3CCx7vt+WPdgDLTHmydkbQSQ==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.3.tgz",
+      "integrity": "sha512-UselcZPwVWNSURnqcfpnxtMehrb8wjXYOimlYQPBnup/Zld426YzIhNEvuRsEWVHfESIECGrxoI6L5QqzuLH5Q==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-function-name": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.2.0.tgz",
-      "integrity": "sha512-kWgksow9lHdvBC2Z4mxTsvc7YdY7w/V6B2vy9cTIPtLEE9NhwoWivaxdNM/S37elu5bqlLP/qOY906LukO9lkQ==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.3.tgz",
+      "integrity": "sha512-uT5J/3qI/8vACBR9I1GlAuU/JqBtWdfCrynuOkrWG6nCDieZd5przB1vfP59FRHBZQ9DC2IUfqr/xKqzOD5x0A==",
       "dev": true,
       "requires": {
         "@babel/helper-function-name": "^7.1.0",
@@ -595,12 +595,12 @@
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.0.tgz",
-      "integrity": "sha512-iWKAooAkipG7g1IY0eah7SumzfnIT3WNhT4uYB2kIsvHnNSB6MDYVa5qyICSwaTBDBY2c4SnJ3JtEa6ltJd6Jw==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.3.tgz",
+      "integrity": "sha512-sMP4JqOTbMJMimqsSZwYWsMjppD+KRyDIUVW91pd7td0dZKAvPmhCaxhOzkzLParKwgQc7bdL9UNv+rpJB0HfA==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.1.0",
+        "@babel/helper-module-transforms": "^7.4.3",
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/helper-simple-access": "^7.1.0"
       }
@@ -654,9 +654,9 @@
       }
     },
     "@babel/plugin-transform-parameters": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.0.tgz",
-      "integrity": "sha512-Xqv6d1X+doyiuCGDoVJFtlZx0onAX0tnc3dY8w71pv/O0dODAbusVv2Ale3cGOwfiyi895ivOBhYa9DhAM8dUA==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.3.tgz",
+      "integrity": "sha512-ULJYC2Vnw96/zdotCZkMGr2QVfKpIT/4/K+xWWY0MbOJyMZuk660BGkr3bEKWQrrciwz6xpmft39nA4BF7hJuA==",
       "dev": true,
       "requires": {
         "@babel/helper-call-delegate": "^7.4.0",
@@ -665,18 +665,18 @@
       }
     },
     "@babel/plugin-transform-regenerator": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.0.tgz",
-      "integrity": "sha512-SZ+CgL4F0wm4npojPU6swo/cK4FcbLgxLd4cWpHaNXY/NJ2dpahODCqBbAwb2rDmVszVb3SSjnk9/vik3AYdBw==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.3.tgz",
+      "integrity": "sha512-kEzotPuOpv6/iSlHroCDydPkKYw7tiJGKlmYp6iJn4a6C/+b2FdttlJsLKYxolYHgotTJ5G5UY5h0qey5ka3+A==",
       "dev": true,
       "requires": {
         "regenerator-transform": "^0.13.4"
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.0.tgz",
-      "integrity": "sha512-1uv2h9wnRj98XX3g0l4q+O3jFM6HfayKup7aIu4pnnlzGz0H+cYckGBC74FZIWJXJSXAmeJ9Yu5Gg2RQpS4hWg==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.3.tgz",
+      "integrity": "sha512-7Q61bU+uEI7bCUFReT1NKn7/X6sDQsZ7wL1sJ9IYMAO7cI+eg6x9re1cEw2fCRMbbTVyoeUKWSV1M6azEfKCfg==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
@@ -733,91 +733,89 @@
       }
     },
     "@babel/plugin-transform-unicode-regex": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.2.0.tgz",
-      "integrity": "sha512-m48Y0lMhrbXEJnVUaYly29jRXbQ3ksxPrS1Tg8t+MHqzXhtBYAvI51euOBaoAlZLPHsieY9XPVMf80a5x0cPcA==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.3.tgz",
+      "integrity": "sha512-lnSNgkVjL8EMtnE8eSS7t2ku8qvKH3eqNf/IwIfnSPUqzgqYmRwzdsQWv4mNQAN9Nuo6Gz1Y0a4CSmdpu1Pp6g==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.0.0",
-        "regexpu-core": "^4.1.3"
+        "@babel/helper-regex": "^7.4.3",
+        "regexpu-core": "^4.5.4"
       }
     },
     "@babel/polyfill": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.4.0.tgz",
-      "integrity": "sha512-bVsjsrtsDflIHp5I6caaAa2V25Kzn50HKPL6g3X0P0ni1ks+58cPB8Mz6AOKVuRPgaVdq/OwEUc/1vKqX+Mo4A==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.4.3.tgz",
+      "integrity": "sha512-rkv8WIvJshA5Ev8iNMGgz5WZkRtgtiPexiT7w5qevGTuT7ZBfM3de9ox1y9JR5/OXb/sWGBbWlHNa7vQKqku3Q==",
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.2"
       }
     },
     "@babel/preset-env": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.4.2.tgz",
-      "integrity": "sha512-OEz6VOZaI9LW08CWVS3d9g/0jZA6YCn1gsKIy/fut7yZCJti5Lm1/Hi+uo/U+ODm7g4I6gULrCP+/+laT8xAsA==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.3.4.tgz",
+      "integrity": "sha512-2mwqfYMK8weA0g0uBKOt4FE3iEodiHy9/CW0b+nWXcbL+pGzLx8ESYc+j9IIxr6LTDHWKgPm71i9smo02bw+gA==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
         "@babel/plugin-proposal-json-strings": "^7.2.0",
-        "@babel/plugin-proposal-object-rest-spread": "^7.4.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.3.4",
         "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
-        "@babel/plugin-proposal-unicode-property-regex": "^7.4.0",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.2.0",
         "@babel/plugin-syntax-async-generators": "^7.2.0",
         "@babel/plugin-syntax-json-strings": "^7.2.0",
         "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
         "@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
         "@babel/plugin-transform-arrow-functions": "^7.2.0",
-        "@babel/plugin-transform-async-to-generator": "^7.4.0",
+        "@babel/plugin-transform-async-to-generator": "^7.3.4",
         "@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-        "@babel/plugin-transform-block-scoping": "^7.4.0",
-        "@babel/plugin-transform-classes": "^7.4.0",
+        "@babel/plugin-transform-block-scoping": "^7.3.4",
+        "@babel/plugin-transform-classes": "^7.3.4",
         "@babel/plugin-transform-computed-properties": "^7.2.0",
-        "@babel/plugin-transform-destructuring": "^7.4.0",
+        "@babel/plugin-transform-destructuring": "^7.2.0",
         "@babel/plugin-transform-dotall-regex": "^7.2.0",
         "@babel/plugin-transform-duplicate-keys": "^7.2.0",
         "@babel/plugin-transform-exponentiation-operator": "^7.2.0",
-        "@babel/plugin-transform-for-of": "^7.4.0",
+        "@babel/plugin-transform-for-of": "^7.2.0",
         "@babel/plugin-transform-function-name": "^7.2.0",
         "@babel/plugin-transform-literals": "^7.2.0",
         "@babel/plugin-transform-modules-amd": "^7.2.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.4.0",
-        "@babel/plugin-transform-modules-systemjs": "^7.4.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.2.0",
+        "@babel/plugin-transform-modules-systemjs": "^7.3.4",
         "@babel/plugin-transform-modules-umd": "^7.2.0",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.4.2",
-        "@babel/plugin-transform-new-target": "^7.4.0",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.3.0",
+        "@babel/plugin-transform-new-target": "^7.0.0",
         "@babel/plugin-transform-object-super": "^7.2.0",
-        "@babel/plugin-transform-parameters": "^7.4.0",
-        "@babel/plugin-transform-regenerator": "^7.4.0",
+        "@babel/plugin-transform-parameters": "^7.2.0",
+        "@babel/plugin-transform-regenerator": "^7.3.4",
         "@babel/plugin-transform-shorthand-properties": "^7.2.0",
         "@babel/plugin-transform-spread": "^7.2.0",
         "@babel/plugin-transform-sticky-regex": "^7.2.0",
         "@babel/plugin-transform-template-literals": "^7.2.0",
         "@babel/plugin-transform-typeof-symbol": "^7.2.0",
         "@babel/plugin-transform-unicode-regex": "^7.2.0",
-        "@babel/types": "^7.4.0",
-        "browserslist": "^4.4.2",
-        "core-js-compat": "^3.0.0",
+        "browserslist": "^4.3.4",
         "invariant": "^2.2.2",
         "js-levenshtein": "^1.1.3",
         "semver": "^5.3.0"
       }
     },
     "@babel/runtime": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.2.tgz",
-      "integrity": "sha512-7Bl2rALb7HpvXFL7TETNzKSAeBVCPHELzc0C//9FCxN8nsiueWSJBqaF+2oIJScyILStASR/Cx5WMkXGYTiJFA==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.3.tgz",
+      "integrity": "sha512-9lsJwJLxDh/T3Q3SZszfWOTkk3pHbkmH+3KY+zwIDmsNlxsumuhS2TH3NIpktU4kNvfzy+k3eLT7aTJSPTo0OA==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.2"
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.4.2.tgz",
-      "integrity": "sha512-y/Br/9uQnumcqcakkmobFqOTzYCWSS6Kuy1b2o7LTXR4lpeU0AhaOcPqIHW85LCxRWUDW5Vg0pU1KlE3YkORlg==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.4.3.tgz",
+      "integrity": "sha512-anTLTF7IK8Hd5f73zpPzt875I27UaaTWARJlfMGgnmQhvEe1uNHQRKBUbXL0Gc0VEYiVzsHsTPso5XdK8NGvFg==",
       "dev": true,
       "requires": {
         "core-js": "^2.6.5",
@@ -836,16 +834,16 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.0.tgz",
-      "integrity": "sha512-/DtIHKfyg2bBKnIN+BItaIlEg5pjAnzHOIQe5w+rHAw/rg9g0V7T4rqPX8BJPfW11kt3koyjAnTNwCzb28Y1PA==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.3.tgz",
+      "integrity": "sha512-HmA01qrtaCwwJWpSKpA948cBvU5BrmviAief/b3AVw936DtcdsTexlbyzNuDnthwhOQ37xshn7hvQaEQk7ISYQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/generator": "^7.4.0",
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-split-export-declaration": "^7.4.0",
-        "@babel/parser": "^7.4.0",
+        "@babel/parser": "^7.4.3",
         "@babel/types": "^7.4.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
@@ -902,9 +900,9 @@
       "dev": true
     },
     "@nuxt/opencollective": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@nuxt/opencollective/-/opencollective-0.2.1.tgz",
-      "integrity": "sha512-NP2VSUKRFGutbhWeKgIU0MnY4fmpH8UWxxwTJNPurCQ5BeWhOxp+Gp5ltO39P/Et/J2GYGb3+ALNqZJ+5cGBBw==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@nuxt/opencollective/-/opencollective-0.2.2.tgz",
+      "integrity": "sha512-ie50SpS47L+0gLsW4yP23zI/PtjsDRglyozX2G09jeiUazC1AJlGPZo0JUs9iuCDUoIgsDEf66y7/bSfig0BpA==",
       "requires": {
         "chalk": "^2.4.1",
         "consola": "^2.3.0",
@@ -1166,9 +1164,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "11.11.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.8.tgz",
-      "integrity": "sha512-87dYasmW2iLSYNTc3WU85taIQb1RBz6KK9w/Hnbkyu3n9xeNd0fbVaPoGMyX1ErGB8PaqNuCtYjpoI9aN6DoCg==",
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.0.tgz",
+      "integrity": "sha512-rx29MMkRdVmzunmiA4lzBYJNnXsW/PhG4kMBy2ATsYaDjGGR75dCFEVVROKpNwlVdcUX3xxlghKQOeDPBJobng==",
       "dev": true
     },
     "@types/q": {
@@ -1230,17 +1228,18 @@
       }
     },
     "@vue/babel-preset-app": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@vue/babel-preset-app/-/babel-preset-app-3.5.1.tgz",
-      "integrity": "sha512-pgZUkMv5a3NBtzuPLtmyf83yMd+D4j16HtWbHCE/v4GDkxeT+v2wle3mOC7rex3jbuxDGtEKT+rdknLXCKStig==",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@vue/babel-preset-app/-/babel-preset-app-3.5.5.tgz",
+      "integrity": "sha512-kK2DkQ+uGOjDnVjgn8A3Rczic55rI42nMESmwWfrfjssPeFQLGqiJixk9eQccHNBjyHcl3D+UOWx+EHQbpPByg==",
       "dev": true,
       "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
         "@babel/plugin-proposal-class-properties": "^7.0.0",
         "@babel/plugin-proposal-decorators": "^7.1.0",
         "@babel/plugin-syntax-dynamic-import": "^7.0.0",
         "@babel/plugin-syntax-jsx": "^7.0.0",
-        "@babel/plugin-transform-runtime": "^7.0.0",
-        "@babel/preset-env": "^7.0.0",
+        "@babel/plugin-transform-runtime": "^7.4.0",
+        "@babel/preset-env": "^7.0.0 < 7.4.0",
         "@babel/runtime": "^7.0.0",
         "@babel/runtime-corejs2": "^7.2.0",
         "@vue/babel-preset-jsx": "^1.0.0-beta.2",
@@ -1295,9 +1294,9 @@
       },
       "dependencies": {
         "camelcase": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
-          "integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.0.tgz",
+          "integrity": "sha512-Y05ICatFYPAfykDIB7VdwSJ0LUl1yq/BwO2OpyGGLjiRe1fgzTwVypPiWnzkGFOVFHXrCXUNBl86bpjBhZWSJg==",
           "dev": true
         }
       }
@@ -1314,23 +1313,23 @@
       },
       "dependencies": {
         "camelcase": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
-          "integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.0.tgz",
+          "integrity": "sha512-Y05ICatFYPAfykDIB7VdwSJ0LUl1yq/BwO2OpyGGLjiRe1fgzTwVypPiWnzkGFOVFHXrCXUNBl86bpjBhZWSJg==",
           "dev": true
         }
       }
     },
     "@vue/cli": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@vue/cli/-/cli-3.5.1.tgz",
-      "integrity": "sha512-BRRwPBetZ5Nj7P9fjq0YpextHuv/Fa7rq6RnNxfY5sgnvM+9lzLKJkaqt6x5FXW2vuPWKVOfQrp3EL6QvIBGeg==",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@vue/cli/-/cli-3.5.5.tgz",
+      "integrity": "sha512-x1zsH1HfThnFEVpUohwp1b94eu9QcPdlyVR48sQdBkqc5D6B0I7yQK9dshhN1ZY4dJAZpED3UklstUQ+knVoCA==",
       "dev": true,
       "requires": {
         "@vue/cli-shared-utils": "^3.5.1",
-        "@vue/cli-ui": "^3.5.1",
-        "@vue/cli-ui-addon-webpack": "^3.5.1",
-        "@vue/cli-ui-addon-widgets": "^3.5.1",
+        "@vue/cli-ui": "^3.5.5",
+        "@vue/cli-ui-addon-webpack": "^3.5.5",
+        "@vue/cli-ui-addon-widgets": "^3.5.5",
         "chalk": "^2.4.1",
         "cmd-shim": "^2.0.2",
         "commander": "^2.16.0",
@@ -1378,13 +1377,13 @@
       "dev": true
     },
     "@vue/cli-plugin-babel": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@vue/cli-plugin-babel/-/cli-plugin-babel-3.5.1.tgz",
-      "integrity": "sha512-b5k8AG21k9y3i5JxNvJzqg0YVFIxN0W/j4urC8Sn3kiNVRii9TBCxoldjKOSWALCJe4mPClR52ivqFWjX4D4/A==",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@vue/cli-plugin-babel/-/cli-plugin-babel-3.5.5.tgz",
+      "integrity": "sha512-ew+EWL2ur234wqQfI1AvWcghjWQ2PlSVpUAfnDlejplDzXSHz7455IIwN7Auhs7siEbls3EVd/bl/ieKGjwY5g==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.0.0",
-        "@vue/babel-preset-app": "^3.5.1",
+        "@vue/babel-preset-app": "^3.5.5",
         "@vue/cli-shared-utils": "^3.5.1",
         "babel-loader": "^8.0.5",
         "webpack": ">=4 < 4.29"
@@ -1433,9 +1432,9 @@
       }
     },
     "@vue/cli-service": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@vue/cli-service/-/cli-service-3.5.1.tgz",
-      "integrity": "sha512-c3xzj2+yrnyziDvkKBTD1cB2jDBs0E4G5gk21hHzvAwzyNSpMPTqwAaeAfUtKHWSgs1dKxi/gURfIgFGUJPn+Q==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@vue/cli-service/-/cli-service-3.5.3.tgz",
+      "integrity": "sha512-28MDRVZe+yebtiSJHfYS6fOvPN1P8DX4BIsDp4rLqZxc7l8yoG6pBWyv9ENT4WO9gAXRGzEsKcJ5qLtXLvQeYQ==",
       "dev": true,
       "requires": {
         "@intervolga/optimize-cssnano-plugin": "^1.0.5",
@@ -1537,9 +1536,9 @@
       }
     },
     "@vue/cli-ui": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@vue/cli-ui/-/cli-ui-3.5.1.tgz",
-      "integrity": "sha512-/yobVdHcQ8/t13YmDmJylrlHXiItl5PLkm2AYc4HrSSbl/jAc/ws3vr3oVqwtLGem2o54nF99sBhxK0L7uhOrw==",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@vue/cli-ui/-/cli-ui-3.5.5.tgz",
+      "integrity": "sha512-Bh2rnvhoaL4iWkzdfGXcUZnsldubRKkaMgn4cgjm+rXjHh37Ww2KPw83JijVk+6qsZbJPoBLcXED0mWWLojhvg==",
       "dev": true,
       "requires": {
         "@akryum/winattr": "^3.0.0",
@@ -1580,15 +1579,15 @@
       }
     },
     "@vue/cli-ui-addon-webpack": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@vue/cli-ui-addon-webpack/-/cli-ui-addon-webpack-3.5.1.tgz",
-      "integrity": "sha512-PaS6m6ipAJefjwngx3WVJ1B4ZxOH4yAGxbQzJcweG98CUppAzBQVvXWQNjqlMDaizMjIUdmpfWhmr5Z6dQ8tJg==",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@vue/cli-ui-addon-webpack/-/cli-ui-addon-webpack-3.5.5.tgz",
+      "integrity": "sha512-JmEJwOQkQYRgdEBLgIkHHE+UUkzO5+5QtDHXW9TlL2LUstLvJdK1bmhikT/zQFr7v9j5mMhre8xYl5rh6A/5kQ==",
       "dev": true
     },
     "@vue/cli-ui-addon-widgets": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@vue/cli-ui-addon-widgets/-/cli-ui-addon-widgets-3.5.1.tgz",
-      "integrity": "sha512-wGKDhmqvknLvQWdNHJEDPD5nRsaC7XspNiCkOXZg7Qm+uutFcu0I83ChKnvYRijhp4Mpmv0o5G50P7UKutM+AQ==",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@vue/cli-ui-addon-widgets/-/cli-ui-addon-widgets-3.5.5.tgz",
+      "integrity": "sha512-64L5r01j4i2xi7b8YZctWF6C/aFrwaJpp0iTlF/nFbPErueHbJTcNYk3zTw8xRWJzBoCRq21np94E5MxNWfaZA==",
       "dev": true
     },
     "@vue/component-compiler-utils": {
@@ -2666,9 +2665,9 @@
       "dev": true
     },
     "ast-types": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.12.2.tgz",
-      "integrity": "sha512-8c83xDLJM/dLDyXNLiR6afRRm4dPKN6KAnKqytRK3DBJul9lA+atxdQkNDkSVPdTqea5HiRq3lnnOIZ0MBpvdg==",
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.12.3.tgz",
+      "integrity": "sha512-wJUcAfrdW+IgDoMGNz5MmcvahKgB7BwIbLupdKVVHxHNYt+HVR2k35swdYNv9aZpF8nvlkjbnkp2rrNwxGckZA==",
       "dev": true
     },
     "async": {
@@ -3008,9 +3007,9 @@
       "dev": true
     },
     "binary-extensions": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.0.tgz",
-      "integrity": "sha512-EgmjVLMn22z7eGGv3kcnHwSnJXmFHjISTY9E/S5lIcTD3Oxw05QTcBLNkJFzcb3cNueUdF/IN4U+d78V0zO8Hw==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+      "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
       "dev": true
     },
     "bl": {
@@ -3140,9 +3139,9 @@
       "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag=="
     },
     "bootstrap-vue": {
-      "version": "2.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.0.0-rc.15.tgz",
-      "integrity": "sha512-ItLol18cs81xkOoMD+DHjeTn/IVPX3OUmxLdE0Y9E3wNis3mP3zsQZCfROGZEB05prhtw55B2fzGXqSe/lzD4g==",
+      "version": "2.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.0.0-rc.16.tgz",
+      "integrity": "sha512-fhiyqG6i3ITF7fAzAjMexikGUgBZ/GTKQi0mCK48FacB5tiq2KUXE0Qilb/CW090PkqEw2W+7AP2/k5/dAa/MQ==",
       "requires": {
         "@nuxt/opencollective": "^0.2.1",
         "bootstrap": "^4.3.1",
@@ -3294,14 +3293,14 @@
       }
     },
     "browserslist": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.2.tgz",
-      "integrity": "sha512-zmJVLiKLrzko0iszd/V4SsjTaomFeoVzQGYYOYgRgsbh7WNh95RgDB0CmBdFWYs/3MyFSt69NypjL/h3iaddKQ==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.3.tgz",
+      "integrity": "sha512-Tx/Jtrmh6vFg24AelzLwCaCq1IUJiMDM1x/LPzqbmbktF8Zo7F9ONUpOWsFK6TtdON95mSMaQUWqi0ilc8xM6g==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30000951",
-        "electron-to-chromium": "^1.3.116",
-        "node-releases": "^1.1.11"
+        "caniuse-lite": "^1.0.30000955",
+        "electron-to-chromium": "^1.3.122",
+        "node-releases": "^1.1.12"
       }
     },
     "buffer": {
@@ -3539,9 +3538,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000953",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000953.tgz",
-      "integrity": "sha512-2stdF/q5MZTDhQ6uC65HWbSgI9UMKbc7+HKvlwH5JBIslKoD/J9dvabP4J4Uiifu3NljbHj3iMpfYflLSNt09A==",
+      "version": "1.0.30000955",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000955.tgz",
+      "integrity": "sha512-6AwmIKgqCYfDWWadRkAuZSHMQP4Mmy96xAXEdRBlN/luQhlRYOKgwOlZ9plpCOsVbBuqbTmGqDK3JUM/nlr8CA==",
       "dev": true
     },
     "capture-stack-trace": {
@@ -4279,9 +4278,9 @@
       "dev": true
     },
     "consola": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-2.5.7.tgz",
-      "integrity": "sha512-KZteEB71fuSoSDgJoYEo/dIvwofWMU/bI/n+wusLYHPp+c7KcxBGZ0P8CzTCko2Jp0xsrbLjmLuUo4jyIWa6vQ=="
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-2.5.8.tgz",
+      "integrity": "sha512-fYv1M0rNJw4h0CZUx8PX02Px7xQhA+vNHpV8DBCGMoozp2Io/vrSXhhEothaRnSt7VMR0rj2pt9KKLXa5amrCw=="
     },
     "console-browserify": {
       "version": "1.1.0",
@@ -4557,32 +4556,6 @@
       "version": "2.6.5",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
       "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
-    },
-    "core-js-compat": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.0.0.tgz",
-      "integrity": "sha512-W/Ppz34uUme3LmXWjMgFlYyGnbo1hd9JvA0LNQ4EmieqVjg2GPYbj3H6tcdP2QGPGWdRKUqZVbVKLNIFVs/HiA==",
-      "dev": true,
-      "requires": {
-        "browserslist": "^4.5.1",
-        "core-js": "3.0.0",
-        "core-js-pure": "3.0.0",
-        "semver": "^5.6.0"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.0.0.tgz",
-          "integrity": "sha512-WBmxlgH2122EzEJ6GH8o9L/FeoUKxxxZ6q6VUxoTlsE4EvbTWKJb447eyVxTEuq0LpXjlq/kCB2qgBvsYRkLvQ==",
-          "dev": true
-        }
-      }
-    },
-    "core-js-pure": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.0.0.tgz",
-      "integrity": "sha512-yPiS3fQd842RZDgo/TAKGgS0f3p2nxssF1H65DIZvZv0Od5CygP8puHXn3IQiM/39VAvgCbdaMQpresrbGgt9g==",
-      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -4993,9 +4966,9 @@
       "dev": true
     },
     "cssstyle": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.2.1.tgz",
-      "integrity": "sha512-7DYm8qe+gPx/h77QlCyFmX80+fGaE/6A/Ekl0zaszYOubvySO2saYFdQ78P29D0UsULxFKCetDGNaNRUdSF+2A==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.2.2.tgz",
+      "integrity": "sha512-43wY3kl1CVQSvL7wUY1qXkxVGkStjpkDmVjiIKX8R97uhajy8Bybay78uOtqvh7Q5GK75dNPfW0geWjE6qQQow==",
       "dev": true,
       "requires": {
         "cssom": "0.3.x"
@@ -5978,9 +5951,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.119",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.119.tgz",
-      "integrity": "sha512-3mtqcAWa4HgG+Djh/oNXlPH0cOH6MmtwxN1nHSaReb9P0Vn51qYPqYwLeoSuAX9loU1wrOBhFbiX3CkeIxPfgg==",
+      "version": "1.3.122",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.122.tgz",
+      "integrity": "sha512-3RKoIyCN4DhP2dsmleuFvpJAIDOseWH88wFYBzb22CSwoFDSWRc4UAMfrtc9h8nBdJjTNIN3rogChgOy6eFInw==",
       "dev": true
     },
     "elliptic": {
@@ -6642,9 +6615,9 @@
       }
     },
     "eslint-plugin-promise": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.0.1.tgz",
-      "integrity": "sha512-Si16O0+Hqz1gDHsys6RtFRrW7cCTB6P7p3OJmKp3Y3dxpQE2qwOA7d3xnV+0mBmrPoi0RBnxlCKvqu70te6wjg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.1.1.tgz",
+      "integrity": "sha512-faAHw7uzlNPy7b45J1guyjazw28M+7gJokKUjC5JSFoYfUEyy6Gw/i7YQvmv2Yk00sUjWcmzXQLpU1Ki/C2IZQ==",
       "dev": true
     },
     "eslint-plugin-standard": {
@@ -6692,9 +6665,9 @@
       "dev": true
     },
     "esm": {
-      "version": "3.2.20",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.20.tgz",
-      "integrity": "sha512-NA92qDA8C/qGX/xMinDGa3+cSPs4wQoFxskRrSnDo/9UloifhONFm4sl4G+JsyCqM007z2K+BfQlH5rMta4K1Q==",
+      "version": "3.2.22",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.22.tgz",
+      "integrity": "sha512-z8YG7U44L82j1XrdEJcqZOLUnjxco8pO453gKOlaMD1/md1n/5QrscAmYG+oKUspsmDLuBFZrpbxI6aQ67yRxA==",
       "dev": true
     },
     "espree": {
@@ -8280,9 +8253,9 @@
           }
         },
         "readable-stream": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
-          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -8392,14 +8365,14 @@
       "dev": true
     },
     "globby": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-9.1.0.tgz",
-      "integrity": "sha512-VtYjhHr7ncls724Of5W6Kaahz0ag7dB4G62/2HsN+xEKG6SrPzM1AJMerGxQTwJGnN9reeyxdvXbuZYpfssCvg==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
+      "integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
       "dev": true,
       "requires": {
         "@types/glob": "^7.1.1",
         "array-union": "^1.0.2",
-        "dir-glob": "^2.2.1",
+        "dir-glob": "^2.2.2",
         "fast-glob": "^2.2.6",
         "glob": "^7.1.3",
         "ignore": "^4.0.3",
@@ -8476,9 +8449,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.1.1.tgz",
-      "integrity": "sha512-C5zDzLqvfPAgTtP8AUPIt9keDabrdRAqSWjj2OPRKrKxI9Fb65I36s1uCs1UUBFnSWTdO7hyHi7z1ZbwKMKF6Q==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.2.1.tgz",
+      "integrity": "sha512-2PL1UbvKeSjy/lUeJqHk+eR9CvuErXoCNwJI4jm3oNFEeY+9ELqHNKO1ZuSxAkasPkpWbmT/iMRMFxd3cEL3tQ==",
       "dev": true,
       "requires": {
         "iterall": "^1.2.2"
@@ -8504,9 +8477,9 @@
       }
     },
     "graphql-subscriptions": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-1.0.0.tgz",
-      "integrity": "sha512-+ytmryoHF1LVf58NKEaNPRUzYyXplm120ntxfPcgOBC7TnK7Tv/4VRHeh4FAR9iL+O1bqhZs4nkibxQ+OA5cDQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-1.1.0.tgz",
+      "integrity": "sha512-6WzlBFC0lWmXJbIVE8OgFgXIP4RJi3OQgTPa0DVMsDXdpRDjTsM1K9wfl5HSYX7R87QAGlvcv2Y4BIZa/ItonA==",
       "dev": true,
       "requires": {
         "iterall": "^1.2.1"
@@ -8532,9 +8505,9 @@
       }
     },
     "graphql-type-json": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.2.2.tgz",
-      "integrity": "sha512-srKbRJWxvZ8J6b7P3F0PrOtKgWg3pxlUPb1xbSIB+aMdK+UPKpp4aDzPV1A+IUTlea6lk9FWwI08UXQApC03lw==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.2.4.tgz",
+      "integrity": "sha512-/tq02ayMQjrG4oDFDRLLrPk0KvJXue0nVXoItBe7uAdbNXjQUu+HYCBdAmPLQoseVzUKKMzrhq2P/sfI76ON6w==",
       "dev": true
     },
     "graphql-upload": {
@@ -8739,9 +8712,9 @@
       }
     },
     "hoek": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.2.tgz",
-      "integrity": "sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
+      "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ==",
       "dev": true
     },
     "homedir-polyfill": {
@@ -8914,9 +8887,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
-          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -9514,9 +9487,9 @@
       "dev": true
     },
     "is-glob": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-      "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
       "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
@@ -10085,9 +10058,9 @@
       }
     },
     "loader-fs-cache": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/loader-fs-cache/-/loader-fs-cache-1.0.1.tgz",
-      "integrity": "sha1-VuC/CL2XCLJqdltoUJhAyN7J/bw=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/loader-fs-cache/-/loader-fs-cache-1.0.2.tgz",
+      "integrity": "sha512-70IzT/0/L+M20jUlEqZhZyArTU6VKLRTYRDAYN26g4jfzpJqjipLL3/hgYpySqI9PwsVRHHFja0LfEmsx9X2Cw==",
       "dev": true,
       "requires": {
         "find-cache-dir": "^0.1.1",
@@ -11509,9 +11482,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.11.tgz",
-      "integrity": "sha512-8v1j5KfP+s5WOTa1spNUAOfreajQPN12JXbRR0oDE+YrJBQCXBnNqUDj27EKpPLOoSiU3tKi3xGPB+JaOdUEQQ==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.13.tgz",
+      "integrity": "sha512-fKZGviSXR6YvVPyc011NHuJDSD8gFQvLPmc2d2V3BS4gr52ycyQ1Xzs7a8B+Ax3Ni/W+5h1h4SqmzeoA8WZRmA==",
       "dev": true,
       "requires": {
         "semver": "^5.3.0"
@@ -11740,9 +11713,9 @@
       "optional": true
     },
     "nwsapi": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.1.tgz",
-      "integrity": "sha512-T5GaA1J/d34AC8mkrFD2O0DR17kwJ702ZOtJOsS8RpbsQZVOC2/xYFb1i/cw+xdM54JIlMuojjDOYct8GIWtwg==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.3.tgz",
+      "integrity": "sha512-RowAaJGEgYXEZfQ7tvvdtAQUKPyTR6T6wNu0fwlNsGQYr/h3yQc6oI8WnVZh3Y/Sylwc+dtAlvPqfFZjhTyk3A==",
       "dev": true
     },
     "oauth-sign": {
@@ -11974,9 +11947,9 @@
       }
     },
     "ora": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-3.2.0.tgz",
-      "integrity": "sha512-XHMZA5WieCbtg+tu0uPF8CjvwQdNzKCX6BVh3N6GFsEXH40mTk5dsw/ya1lBTUGJslcEFJFQ8cBhOgkkZXQtMA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-3.3.1.tgz",
+      "integrity": "sha512-k80K0Q6hYokgaJoFePrxJfQJeZKZ38GVEI/BLNxAJXtQZGcMc5jLIAO9ttoI8A52wvfHmdySy8F52gz/sfFFFA==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",
@@ -12128,9 +12101,9 @@
       "dev": true
     },
     "p-try": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
-      "integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
     "pac-proxy-agent": {
@@ -13582,12 +13555,12 @@
       }
     },
     "recast": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.17.4.tgz",
-      "integrity": "sha512-94mbtFr2e4XoleJVCQQ138gK7xT2IScq25+thwEzNWd/hjOXQd6ejFiztgZZGVSByoV7/k3pLBXO3RK1BvJsIw==",
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.17.5.tgz",
+      "integrity": "sha512-K+DgfAMIyEjNKjaFSWgg9TTu7wFgU/4KTyw4E9vl6M5QPDuUYbyt49Yzb0EIDbZks+6lXk/UZ9eTuE4jlLyf2A==",
       "dev": true,
       "requires": {
-        "ast-types": "0.12.2",
+        "ast-types": "0.12.3",
         "esprima": "~4.0.0",
         "private": "^0.1.8",
         "source-map": "~0.6.1"
@@ -14402,9 +14375,9 @@
       }
     },
     "semver": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
       "dev": true
     },
     "semver-diff": {
@@ -14682,14 +14655,14 @@
       }
     },
     "sinon": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.3.0.tgz",
-      "integrity": "sha512-0pYvgRv46fODzT/PByqb79MVNpyxsxf38WEiXTABOF8RfIMcIARfZ+1ORuxwAmHkreZ/jST3UDBdKCRhUy/e1A==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.3.1.tgz",
+      "integrity": "sha512-eQKMaeWovtOtYe2xThEvaHmmxf870Di+bim10c3ZPrL5bZhLGtu8cz+rOBTFz0CwBV4Q/7dYwZiqZbGVLZ+vjQ==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.4.0",
         "@sinonjs/formatio": "^3.2.1",
-        "@sinonjs/samsam": "^3.3.0",
+        "@sinonjs/samsam": "^3.3.1",
         "diff": "^3.5.0",
         "lolex": "^3.1.0",
         "nise": "^1.4.10",
@@ -15033,9 +15006,9 @@
           }
         },
         "readable-stream": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
-          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -16903,9 +16876,9 @@
           }
         },
         "mem": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/mem/-/mem-4.2.0.tgz",
-          "integrity": "sha512-5fJxa68urlY0Ir8ijatKa3eRz5lwXnRCTvo9+TbTGAuTFJOwpGcY0X05moBd0nW45965Njt4CDI2GFQoG8DvqA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+          "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
           "dev": true,
           "requires": {
             "map-age-cleaner": "^0.1.1",
@@ -16914,9 +16887,9 @@
           }
         },
         "mimic-fn": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.0.0.tgz",
-          "integrity": "sha512-jbex9Yd/3lmICXwYT6gA/j2mNQGU48wCh/VzRd+/Y/PjYQtlg1gLMdZqvu9s/xH7qKvngxRObl56XZR609IMbA==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
           "dev": true
         },
         "os-locale": {
@@ -17217,9 +17190,9 @@
       }
     },
     "ws": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.0.tgz",
-      "integrity": "sha512-deZYUNlt2O4buFCa3t5bKLf8A7FPP/TVjwOeVNpw818Ma5nk4MLXls2eoEGS39o8119QIYxTrTDoPQ5B/gTD6w==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+      "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
       "dev": true,
       "requires": {
         "async-limiter": "~1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monarch-ui",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "private": true,
   "scripts": {
     "clean": "rm -rf dist/",
@@ -18,7 +18,7 @@
     "ghpublish": "./publish.sh"
   },
   "dependencies": {
-    "@babel/polyfill": "^7.4.0",
+    "@babel/polyfill": "^7.4.3",
     "axios": "^0.18.0",
     "babel-polyfill": "^6.26.0",
     "bootstrap": "4.3.1",
@@ -44,12 +44,12 @@
     "vue-router": "^3.0.2"
   },
   "devDependencies": {
-    "@vue/cli": "^3.5.1",
-    "@vue/cli-plugin-babel": "^3.5.1",
+    "@vue/cli": "^3.5.5",
+    "@vue/cli-plugin-babel": "^3.5.5",
     "@vue/cli-plugin-e2e-nightwatch": "^3.5.1",
     "@vue/cli-plugin-eslint": "^3.5.1",
     "@vue/cli-plugin-unit-mocha": "^3.5.1",
-    "@vue/cli-service": "^3.5.1",
+    "@vue/cli-service": "^3.5.3",
     "@vue/eslint-config-airbnb": "^4.0.0",
     "@vue/eslint-config-standard": "^4.0.0",
     "@vue/test-utils": "^1.0.0-beta.29",
@@ -62,7 +62,7 @@
     "http-server": "^0.11.1",
     "node-sass": "^4.11.0",
     "sass-loader": "^7.1.0",
-    "sinon": "^7.3.0",
+    "sinon": "^7.3.1",
     "vue-cli-plugin-bootstrap-vue": "^0.2.0",
     "vue-cli-plugin-webpack-bundle-analyzer": "^1.2.0",
     "vue-markdown-loader": "^2.4.1",

--- a/src/components/AssocTable.vue
+++ b/src/components/AssocTable.vue
@@ -237,6 +237,9 @@ export default {
           }
         });
       return truth;
+    },
+    allFacets() {
+      return Object.entries(this.facets.species).map(elem => this.keyMap(elem[0]));
     }
   },
   watch: {
@@ -416,7 +419,7 @@ export default {
         ];
         let pubsLength = 0;
         if (elem.publications) {
-          pubs = this.parsePublications(elem.publications);
+          pubs = this.parsePublications(elem.publications, elem.object.id);
           pubsLength += pubs.length;
         }
         let evidence = [
@@ -477,8 +480,15 @@ export default {
         const supportLength = support.length;
         // console.log('support');
         // console.log(JSON.stringify(support, null, 2));
-        if (!taxon.id || this.trueFacets.includes(taxon.id)) {
-          const simplifiedCardType = this.cardType.replace(/ortholog-/g, '');
+        if (taxon.id && this.allFacets.includes(taxon.id) && !this.trueFacets.includes(taxon.id)) {
+          console.log('skipping', taxon.id, elem);
+        }
+        else {
+          let simplifiedCardType = this.cardType.replace(/ortholog-/g, '');
+          if (simplifiedCardType === 'interaction') {
+            simplifiedCardType = 'gene';
+          }
+
           let objectLink = `/${simplifiedCardType}/${objectElem.id}`;
           if (objectElem.id.indexOf(':.well-known') === 0) {
             objectLink = null;
@@ -559,10 +569,10 @@ export default {
       }
       return result;
     },
-    parsePublications(pubsList) {
+    parsePublications(pubsList, selfId) {
       const pubs = [];
       pubsList.forEach((elem) => {
-        if (elem.id !== this.nodeId) {
+        if (elem.id !== this.nodeId && elem.id !== selfId) {
           pubs.push(elem.id);
         }
       });

--- a/src/components/MonarchAutocomplete.vue
+++ b/src/components/MonarchAutocomplete.vue
@@ -19,7 +19,7 @@
           type="button"
           @click="toggleFilterBox"
         >
-          All
+          {{ categories.map((c) => { return firstCap(c); }).join(', ') }}
         </button>
         <div
           v-if="catDropDown"
@@ -99,10 +99,12 @@
             >
               <strong>{{ suggestion.match }}</strong>
             </div>
-            <div class="col-4">
+            <div
+              class="col-4">
               <i>{{ suggestion.taxon }}</i>
             </div>
-            <div class="col-3 text-align-right">
+            <div
+              class="col-3 text-align-right">
               <small>{{ suggestion.category }}</small>
             </div>
           </div>
@@ -271,7 +273,7 @@ export default {
         },
         {
           text: 'Variant',
-          value: 'variant locus',
+          value: 'variant',
         },
         {
           text: 'Phenotype',
@@ -386,7 +388,7 @@ export default {
     categoryMap(catList) {
       const validCats = {
         'gene': 'gene',
-        'variant locus': 'variant',
+        'variant': 'variant',
         'Phenotype': 'phenotype',
         'genotype': 'genotype',
         'disease': 'disease'

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -133,6 +133,11 @@
           </b-dropdown-item>
 
           <b-dropdown-item
+            to="/gene/HGNC:11180">
+            Gene: SOD2 HGNC:11180
+          </b-dropdown-item>
+
+          <b-dropdown-item
             to="/disease/MONDO:0010156">
             Disease: Troyer Syndrome MONDO:0010156
           </b-dropdown-item>

--- a/src/main.js
+++ b/src/main.js
@@ -39,4 +39,4 @@ debugSpinnerLink.addEventListener('click', () => {
   debugLogos[1].classList.toggle('rotate');
 });
 
-window.MonarchUIVersion = '0.0.10';
+window.MonarchUIVersion = '0.0.11';

--- a/src/views/Node.vue
+++ b/src/views/Node.vue
@@ -187,15 +187,8 @@
               <span
                 v-for="r in equivalentClasses"
                 :key="r.id">
-                <router-link
-                  v-if="r.id"
-                  :to="'/resolve/' + r.id">
-                  {{ r.label || r.id }}
-                </router-link>
-
-                <span
-                  v-else>
-                  {{ r.label }}
+                <span>
+                  {{ r.id }}&nbsp;
                 </span>
               </span>
             </div>
@@ -232,7 +225,7 @@
           </div>
 
           <div
-            v-if="!expandedCard && node.geneInfo"
+            v-if="!expandedCard && node.geneInfo && node.geneInfo.hits[0]"
             class="row">
             <genome-feature
               :mygene-data="node.geneInfo"/>
@@ -526,7 +519,6 @@ export default {
       const equivalentClasses = neighborhood.equivalentClasses;
       const superclasses = neighborhood.superclasses;
       const subclasses = neighborhood.subclasses;
-
       this.superclasses = us.map(us.uniq(superclasses), c => ({
         id: c,
         label: nodeLabelMap[c]
@@ -542,6 +534,7 @@ export default {
       // console.log('superclasses', this.superclasses);
       // console.log('subclasses', this.subclasses);
       // console.log('equivalentClasses', this.equivalentClasses);
+      // console.log('equivalentClasses', equivalentClasses);
 
       this.synonyms = this.node.synonyms;
       this.xrefs = this.node.xrefs;
@@ -563,35 +556,20 @@ export default {
       this.hasGeneExac = (this.nodeType === 'gene' || this.nodeType === 'variant');
 
       const nonEmptyCards = [];
-      // console.log('that.node.association_counts', that.node);
-      this.availableCards.forEach((cardType) => {
-        const acount = that.node.association_counts[cardType] || 0;
-        if (acount) {
-          that.counts[cardType] = acount;
-          if (acount > 0) {
-            nonEmptyCards.push(cardType);
+      if (!that.node.association_counts) {
+        console.log('Missing association_counts', that.node);
+      }
+      else {
+        this.availableCards.forEach((cardType) => {
+          const acount = that.node.association_counts[cardType] || 0;
+          if (acount) {
+            that.counts[cardType] = acount;
+            if (acount > 0) {
+              nonEmptyCards.push(cardType);
+            }
           }
-        }
-
-        // const count = that.node.counts[cardType];
-        // let ccount = 0;
-        // if (!count) {
-        //   console.log('missing', cardType);
-        // }
-        // else {
-        //   ccount = count.totalCount;
-        // }
-        // const acount = that.node.association_counts[cardType] || 0;
-        // if (ccount !== acount) {
-        //   console.log('mismatch', cardType, ccount, acount);
-        // }
-        // if (ccount) {
-        //   that.counts[cardType] = ccount;
-        //   if (ccount > 0) {
-        //     nonEmptyCards.push(cardType);
-        //   }
-        // }
-      });
+        });
+      }
       this.nonEmptyCards = nonEmptyCards;
 
       const hash = this.$router.currentRoute.hash;

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -73,7 +73,7 @@ const validCats = {
   'phenotype': 'phenotype',
   'genotype': 'genotype',
   'disease': 'disease',
-  'variant locus': 'variant',
+  'variant': 'variant',
 };
 
 export default {

--- a/vue.config.js
+++ b/vue.config.js
@@ -29,7 +29,6 @@ mdLoaderPlain.wrapperClass = 'vue-markdown-plain';
 // const GenomeFeatureViewerCSS = path.resolve(__dirname, 'node_modules/genomefeaturecomponent/dist/GenomeFeatureViewer.css');
 const GenomeFeatureViewer = path.resolve(__dirname, 'node_modules/genomefeaturecomponent/src/index.js');
 const GenomeFeatureViewerCSS = path.resolve(__dirname, 'node_modules/genomefeaturecomponent/src/GenomeFeatureViewer.css');
-const esprima = path.resolve(__dirname, 'node_modules/genomefeaturecomponent/src/index.js');
 
 const vueConfig = {
   // outputDir: 'dist',


### PR DESCRIPTION
- Set default BL API server to 'production'
- Add hack to workaround BL problem where /bioentity/function/{id} is not what you'd expect by symmetry. Basically, exploit the /bioentity/{id} endpoint when the nodeType is 'function'. Hopefully, BL will get fixed and this kludge can be removed.
- Eliminate the whole 'variant locus' vs 'variant' code that polluted the UI. Seems to work fine without it, and if it shows up as a problem, we'll hack it in BioLink.js rather than having the UI deal.
- Eliminate previous kludges for anatomy/gene now that BL production has been fixed/updated.
- Handle MyGene responses for genes with multiple genomic_pos. As per CMungall's suggestion, I am merging the ranges and using the merged range start/end to feel the Apollo server at AGR, to drive the GenomeFeatureViewer. Seems to work.
- Added some debug warnings to detect anomalies in MyGene responses.
- When displaying a Publication as support, do not display it if you are viewing the same Publication (eliminate self-references in the Support section, basically)
- Special-case the Interactions association list so that 'gene' links are generated instead of 'interaction' links, because we currently don't have a meaningful interpretation of an 'Interaction' as a BioEntity. If we ever think of one, then we should have an Interaction node page.
- Eliminate unnecessary esprima reference from vue.config.js
