### PR TITLE
removed redundant footer in sources

### DIFF
--- a/src/views/Sources.vue
+++ b/src/views/Sources.vue
@@ -39,7 +39,6 @@
         </script>
       </div>
     </div>
-    <monarch-footer/>
   </div>
 
 


### PR DESCRIPTION
Sources pages has two footers at the bottom:
https://beta.monarchinitiative.org/sources