### PR TITLE
Temporary prettification of source page

### DIFF
--- a/src/api/BioLink.js
+++ b/src/api/BioLink.js
@@ -297,16 +297,16 @@ export async function getSources() {
 
   const bioentityResp = await axios.get(url, { params });
 
-    // remove this after we get this stuff from the API
-    for (var i = 0; i < bioentityResp.data.length; i++) {
-	var sourceDisplayName = bioentityResp.data[i].id.split(/[:.]+/)[1]
-	sourceDisplayName = sourceDisplayName.charAt(0).toUpperCase() + sourceDisplayName.slice(1);
-	bioentityResp.data[i].sourceDisplayName = sourceDisplayName
-	bioentityResp.data[i].ttlUrl = "https://data.monarchinitiative.org/ttl/" + bioentityResp.data[i].id.split(":")[1]
-	bioentityResp.data[i].sourceVersion = bioentityResp.data[i].meta.version[0]	
-	bioentityResp.data[i].monarchDataReleaseDate = "2019-02-22"
-    }
-    
+  // remove this after we get this stuff from the API
+  for (let i = 0; i < bioentityResp.data.length; i++) {
+    let sourceDisplayName = bioentityResp.data[i].id.split(/[:.]+/)[1];
+    sourceDisplayName = sourceDisplayName.charAt(0).toUpperCase() + sourceDisplayName.slice(1);
+    bioentityResp.data[i].sourceDisplayName = sourceDisplayName;
+    bioentityResp.data[i].ttlUrl = 'https://data.monarchinitiative.org/ttl/' + bioentityResp.data[i].id.split(':')[1];
+    bioentityResp.data[i].sourceVersion = bioentityResp.data[i].meta.version[0];
+    bioentityResp.data[i].monarchDataReleaseDate = '2019-02-22';
+  }
+
   const data = bioentityResp.data;
 
   return data;

--- a/src/api/BioLink.js
+++ b/src/api/BioLink.js
@@ -296,6 +296,17 @@ export async function getSources() {
   const params = new URLSearchParams();
 
   const bioentityResp = await axios.get(url, { params });
+
+    // remove this after we get this stuff from the API
+    for (var i = 0; i < bioentityResp.data.length; i++) {
+	var sourceDisplayName = bioentityResp.data[i].id.split(/[:.]+/)[1]
+	sourceDisplayName = sourceDisplayName.charAt(0).toUpperCase() + sourceDisplayName.slice(1);
+	bioentityResp.data[i].sourceDisplayName = sourceDisplayName
+	bioentityResp.data[i].ttlUrl = "https://data.monarchinitiative.org/ttl/" + bioentityResp.data[i].id.split(":")[1]
+	bioentityResp.data[i].sourceVersion = bioentityResp.data[i].meta.version[0]	
+	bioentityResp.data[i].monarchDataReleaseDate = "2019-02-22"
+    }
+    
   const data = bioentityResp.data;
 
   return data;

--- a/src/views/Sources.vue
+++ b/src/views/Sources.vue
@@ -5,7 +5,7 @@
     <div class="container">
       <div class="row border">
         <div class="col-4">  Source </div>
-        <div class="col-4">  Source Version </div>	
+        <div class="col-4">  Source Version </div>
         <div class="col-4">  Monarch data release date </div>
       </div>
       <div
@@ -15,11 +15,11 @@
         <div class="col-4">
           <a
             :href="source.ttlUrl"
-            target="_blank">{{ source.sourceDisplayName}}
+            target="_blank">{{ source.sourceDisplayName }}
           </a>
         </div>
-        <div class="col-4"> {{ source.sourceVersion }}</div>	
-	<div class="col-4"> {{ source.monarchDataReleaseDate }}</div>	
+        <div class="col-4"> {{ source.sourceVersion }}</div>
+        <div class="col-4"> {{ source.monarchDataReleaseDate }}</div>
         <script type="application/ld+json">
           {
           "@context": "http://schema.org",

--- a/src/views/Sources.vue
+++ b/src/views/Sources.vue
@@ -4,31 +4,29 @@
     <h1>Monarch Sources</h1>
     <div class="container">
       <div class="row border">
-        <div class="col-1">  id </div>
-        <div class="col-6">  title </div>
-        <div class="col-2">  version </div>
-        <div class="col-3">  url </div>
+        <div class="col-4">  Source </div>
+        <div class="col-4">  Source Version </div>	
+        <div class="col-4">  Monarch data release date </div>
       </div>
       <div
         v-for="(source, index) in sources"
         :key="index"
         class="row">
-        <div class="col-1"> {{ source.id }}</div>
-        <div class="col-6"> {{ source.title }}</div>
-        <div class="col-2"> {{ source.meta.version[0] }}</div>
-        <div class="col-3">
+        <div class="col-4">
           <a
-            :href="source.url"
-            target="_blank">{{ source.url }}
+            :href="source.ttlUrl"
+            target="_blank">{{ source.sourceDisplayName}}
           </a>
         </div>
+        <div class="col-4"> {{ source.sourceVersion }}</div>	
+	<div class="col-4"> {{ source.monarchDataReleaseDate }}</div>	
         <script type="application/ld+json">
           {
           "@context": "http://schema.org",
           "@type": "Dataset",
-          "name": "Monarch transformation of {{ source.title }}",
+          "name": "Monarch transformation of {{ source.sourceDisplayName }}",
           "description": "Monarch transformation of: {{ source.description }}",
-          "url": "{{ source.url }}",
+          "url": "{{ source.ttlUrl }}",
           "includedInDataCatalog": "https://monarchinitiative.org",
           "creator": {
           "@type": "Organization",


### PR DESCRIPTION
to address https://github.com/monarch-initiative/monarch-ui/issues/58, slightly hacky injection of data about sources until we get these data from the API

@kshefchek @deepakunni3 have a look, I think this looks slightly better than the current source page. When we can pull these data from the API
	`data.sourceDisplayName`
	`data.ttlUrl`
	`data.sourceVersion`
	`data.monarchDataReleaseDate`
we can remove the hacktastic code I made below and things should work as normal. 

```
    // remove this after we get this stuff from the API
    for (var i = 0; i < bioentityResp.data.length; i++) {
	var sourceDisplayName = bioentityResp.data[i].id.split(/[:.]+/)[1]
	sourceDisplayName = sourceDisplayName.charAt(0).toUpperCase() + sourceDisplayName.slice(1);
	bioentityResp.data[i].sourceDisplayName = sourceDisplayName
	bioentityResp.data[i].ttlUrl = "https://data.monarchinitiative.org/ttl/" + bioentityResp.data[i].id.split(":")[1]
	bioentityResp.data[i].sourceVersion = bioentityResp.data[i].meta.version[0]	
	bioentityResp.data[i].monarchDataReleaseDate = "2019-02-22"
    }
```