### PR TITLE
Improvements to search and autocomplete

### DIFF
--- a/src/api/BioLink.js
+++ b/src/api/BioLink.js
@@ -583,13 +583,12 @@ export async function getSearchResults(query, start, rows, categories, taxa) {
   const params = new URLSearchParams();
   params.append('start', start);
   params.append('rows', rows);
-  params.append('fetch_objects', false);
-  params.append('exclude_automatic_assertions', false);
-  params.append('exclude_automatic_assertions', false);
-  params.append('use_compact_associations', true);
   params.append('highlight_class', 'hilite');
   params.append('boost_q', 'category:genotype^-10');
+  params.append('boost_q', 'category:variant^-35');
   params.append('prefix', '-OMIA');
+  params.append('min_match', '67%');
+
 
   let categoriesLocal = categories;
   if (!categoriesLocal || categoriesLocal.length === 0) {
@@ -621,13 +620,15 @@ export async function getSearchTermSuggestions(term, category, prefixes) {
   params.append('start', 0);
   params.append('highlight_class', 'hilite');
   params.append('boost_q', 'category:genotype^-10');
+  params.append('boost_q', 'category:variant^-35');
+  params.append('prefix', '-OMIA');
+  params.append('min_match', '67%');
 
   if (prefixes && prefixes.length) {
     prefixes.forEach((elem) => {
       params.append('prefix', elem);
     });
   }
-  params.append('prefix', '-OMIA');
 
   if (!category || category === 'all') {
     category = categoriesAll;
@@ -640,8 +641,13 @@ export async function getSearchTermSuggestions(term, category, prefixes) {
     params.append('category', elem);
   });
 
-  if (category.indexOf('gene') >= 0) {
-    params.append('boost_fx', 'pow(edges,0.334)');
+  if (category.length === 1) {
+    if (category[0] === 'gene') {
+      params.append('boost_fx', 'pow(edges,0.334)');
+    }
+    if (category[0] === 'variant' || category[0] === 'genotype') {
+      params.append('minimal_tokenizer', true);
+    }
   }
 
   const returnedPromise = new Promise((resolve, reject) => {


### PR DESCRIPTION
Autocomplete changes

- If a user selects "gene", boost results based on connected edges
- If a user selects variant or genotype, use a minimal tokenizer
- down weight variants
- remove params that are not part of the rest call (interesting that an error is not returned)
- Set [minimum should match](https://lucene.apache.org/solr/guide/6_6/the-dismax-query-parser.html#TheDisMaxQueryParser-Themm_MinimumShouldMatch_Parameter) param to 67%

Search changes
- down weight variants
- Set [minimum should match](https://lucene.apache.org/solr/guide/6_6/the-dismax-query-parser.html#TheDisMaxQueryParser-Themm_MinimumShouldMatch_Parameter) param to 67%

See https://kshefchek.github.io/monarch-ui/