### PR TITLE
Use monarch solr (via biolink) until ontobio amigo is ready

### DIFF
--- a/src/api/BioLink.js
+++ b/src/api/BioLink.js
@@ -691,8 +691,14 @@ export async function getNodeAssociations(nodeType, nodeId, cardType, taxons, pa
   const baseUrl = `${biolink}bioentity/`;
   const biolinkMappedCardType = getBiolinkAnnotation(cardType);
   const urlExtension = `${nodeType}/${nodeId}/${biolinkMappedCardType}`;
-  const url = `${baseUrl}${urlExtension}`;
+  let url = `${baseUrl}${urlExtension}`;
   const useTaxonRestriction = taxons && taxons.length > 0 && isTaxonCardType(cardType);
+
+  // Use monarch solr until amigo-ontobio connection is ready
+  if (cardType === 'function') {
+    url = `${biolink}association/type/gene_function`;
+    params.subject = nodeId;
+  }
 
   if (useTaxonRestriction) {
     // console.log('getNodeAssociations', nodeType, nodeId, cardType);


### PR DESCRIPTION
This is a proposal to use the monarch solr for gene to function associations to replicate what we have on production.  Proposing this to get us to 1.0 and add the amigo work in 1.1  For comparison:

Current beta
https://beta.monarchinitiative.org/gene/HGNC:10848#function

Current Prod
https://monarchinitiative.org/gene/HGNC:10848#functions

This PR:
https://kshefchek.github.io/monarch-ui/gene/HGNC:10848#function

cc @monicacecilia @deepakunni3 @cmungall 