### PR TITLE
Manually set ingest dates for ClinVar and UDP on data sources page

### DIFF
--- a/src/api/BBOPGraphUtil.js
+++ b/src/api/BBOPGraphUtil.js
@@ -72,7 +72,7 @@ export function mergeStaticData(sourceData, staticSourceData) {
   // iterate through staticSourceData and populate sources that aren't in dynamic data from biolink-api (e.g. ClinVar)
   us.each(staticSourceData, function fn(staticDatum) {
     if (!dynamicSummaryIRIs.includes(staticDatum.summaryIRI)) {
-      var newSourceEntry = populateSourceTemplate({ '_summary_iri': staticDatum.summaryIRI });
+      const newSourceEntry = populateSourceTemplate({ '_summary_iri': staticDatum.summaryIRI });
       Object.assign(newSourceEntry, staticDatum);
       sourceData.push(newSourceEntry);
     }
@@ -93,7 +93,7 @@ export function populateSourceFiles(sourceData, graph) {
         return { 'fileUrl': source, 'retrievedOn': retVal };
       })
       .map(function fixCuriePrefixes(source) {
-        us.each(curiePrefixURLs, function (value, key) {
+        us.each(curiePrefixURLs, function fix(value, key) {
           source.fileUrl = source.fileUrl.replace(key + ':', value);
         });
         return source;
@@ -112,7 +112,7 @@ export function populateRdfDownloadUrl(sourceData, graph) {
   for (let i = 0; i < sourceData.length; i++) {
     const distributionIRI = _versionIRI2distributionIRI(sourceData[i]._version_iri, graph);
     const downloadUrl = _subjectPredicate2Object(distributionIRI, predicates.downloadUrl, graph);
-    sourceData[i].rdfDownloadUrl = downloadUrl.replace("MonarchArchive:", curiePrefixURLs.MonarchArchive);
+    sourceData[i].rdfDownloadUrl = downloadUrl.replace('MonarchArchive:', curiePrefixURLs.MonarchArchive);
   }
 }
 

--- a/src/api/BBOPGraphUtil.js
+++ b/src/api/BBOPGraphUtil.js
@@ -18,7 +18,7 @@ const curiePrefixURLs = { // various curie prefixes that need to be fixed/expand
   'CoriellCollection': 'https://catalog.coriell.org/1/',
   'OBO': 'http://purl.obolibrary.org/obo/',
   'ZFIN': 'http://zfin.org/',
-}
+};
 
 export function populateSourceTemplate(datum) {
   return {
@@ -70,10 +70,10 @@ export function mergeStaticData(sourceData, staticSourceData) {
   });
 
   // iterate through staticSourceData and populate sources that aren't in dynamic data from biolink-api (e.g. ClinVar)
-  us.each(staticSourceData, function fn(staticDatum){
-    if(! dynamicSummaryIRIs.includes(staticDatum.summaryIRI)){
-      var newSourceEntry = populateSourceTemplate({'_summary_iri': staticDatum.summaryIRI} );
-      Object.assign(newSourceEntry, staticDatum)
+  us.each(staticSourceData, function fn(staticDatum) {
+    if (!dynamicSummaryIRIs.includes(staticDatum.summaryIRI)) {
+      var newSourceEntry = populateSourceTemplate({ '_summary_iri': staticDatum.summaryIRI });
+      Object.assign(newSourceEntry, staticDatum);
       sourceData.push(newSourceEntry);
     }
   });
@@ -94,7 +94,7 @@ export function populateSourceFiles(sourceData, graph) {
       })
       .map(function fixCuriePrefixes(source) {
         us.each(curiePrefixURLs, function (value, key) {
-          source['fileUrl'] = source['fileUrl'].replace(key + ":", value);
+          source.fileUrl = source.fileUrl.replace(key + ':', value);
         });
         return source;
       })

--- a/src/api/StaticSourceData.js
+++ b/src/api/StaticSourceData.js
@@ -299,7 +299,7 @@ export default function getStaticSourceData() {
 
       // this will need updating periodically:
       ingestDate: '2019-03-16',
-      rdfDownloadUrl: 'https://archive.monarchinitiative.org/201911/rdf/udp.ttl',
+      rdfDownloadUrl: 'https://archive.monarchinitiative.org/201911/rdf/udp.ttl'
     }
   ];
 

--- a/src/api/StaticSourceData.js
+++ b/src/api/StaticSourceData.js
@@ -272,8 +272,6 @@ export default function getStaticSourceData() {
       sourceDescription: "ClinVar archives and aggregates information about relationships among variation and human health. ClinVar collects reports of variants found in patient samples, assertions made regarding their clinical significance, information about the submitter, and other supporting data.",
       monarchUsage: "disease-gene association, variant-disease association, variant definitions",
       vocabulary: "UMLS",
-      ingestDate: 'Unknown',
-      rdfDownloadUrl: 'https://archive.monarchinitiative.org/201910/rdf/clinvar.nt',
       sourceFiles: [
         {
           'fileUrl': "ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/xml/ClinVarFullRelease_00-latest.xml.gz",
@@ -285,24 +283,34 @@ export default function getStaticSourceData() {
         }
       ],
       logoUrl: '/img/sources/source-clinvar.png',
-      summaryIRI: "MonarchArchive:#clinvar"
+      summaryIRI: "MonarchArchive:#clinvar",
+
+      // this will need updating periodically:
+      ingestDate: '2019-11-12',
+      rdfDownloadUrl: 'https://archive.monarchinitiative.org/201910/rdf/clinvar.nt'
     },
     {
       sourceDisplayName: "Undiagnosed Diseases Program (UDP)",
       sourceDescription: "The National Institutes of Health (NIH) Undiagnosed Diseases Program (UDP) is part of the Undiagnosed Disease Network (UDN), an NIH Common Fund initiative that focuses on the most puzzling medical cases referred to the NIH Clinical Center in Bethesda, Maryland.",
       monarchUsage: "Monarch stores phenotypes for each case and variants of interest",
       vocabulary: "RO",
-      ingestDate: 'Unknown',
-      rdfDownloadUrl: 'https://archive.monarchinitiative.org/201910/rdf/udp.ttl',
       logoUrl: '/img/sources/source-udp.png',
-      summaryIRI: "MonarchArchive:#udp"
+      summaryIRI: "MonarchArchive:#udp",
+
+      // this will need updating periodically:
+      ingestDate: '2019-03-16',
+      rdfDownloadUrl: 'https://archive.monarchinitiative.org/201910/rdf/udp.ttl',
     },
     {
       sourceDisplayName: "Gene Reviews",
       sourceDescription: "GeneReviews, an international point-of-care resource for busy clinicians, provides clinically relevant and medically actionable information for inherited conditions in a standardized journal-style format, covering diagnosis, management, and genetic counseling for patients and their families.",
       monarchUsage: "Monarch processes the GeneReviews mappings to OMIM, plus inspect the GeneReviews (html) books to pull the clinical descriptions in order to populate the definitions of the terms in the ontology. We define the GeneReviews items as classes that are either grouping classes over OMIM disease ids (gene ids are filtered out), or are made as subclasses of DOID:4 (generic disease).",
       vocabulary: "",
-      summaryIRI: "MonarchArchive:#genereviews"
+      summaryIRI: "MonarchArchive:#genereviews",
+
+      // this will need updating periodically:
+      ingestDate: '2019-11-12',
+      rdfDownloadUrl: 'https://archive.monarchinitiative.org/201910/rdf/genereviews.ttl',
     }
   ];
 

--- a/src/api/StaticSourceData.js
+++ b/src/api/StaticSourceData.js
@@ -300,17 +300,6 @@ export default function getStaticSourceData() {
       // this will need updating periodically:
       ingestDate: '2019-03-16',
       rdfDownloadUrl: 'https://archive.monarchinitiative.org/201910/rdf/udp.ttl',
-    },
-    {
-      sourceDisplayName: "Gene Reviews",
-      sourceDescription: "GeneReviews, an international point-of-care resource for busy clinicians, provides clinically relevant and medically actionable information for inherited conditions in a standardized journal-style format, covering diagnosis, management, and genetic counseling for patients and their families.",
-      monarchUsage: "Monarch processes the GeneReviews mappings to OMIM, plus inspect the GeneReviews (html) books to pull the clinical descriptions in order to populate the definitions of the terms in the ontology. We define the GeneReviews items as classes that are either grouping classes over OMIM disease ids (gene ids are filtered out), or are made as subclasses of DOID:4 (generic disease).",
-      vocabulary: "",
-      summaryIRI: "MonarchArchive:#genereviews",
-
-      // this will need updating periodically:
-      ingestDate: '2019-11-12',
-      rdfDownloadUrl: 'https://archive.monarchinitiative.org/201910/rdf/genereviews.ttl',
     }
   ];
 

--- a/src/api/StaticSourceData.js
+++ b/src/api/StaticSourceData.js
@@ -287,7 +287,7 @@ export default function getStaticSourceData() {
 
       // this will need updating periodically:
       ingestDate: '2019-11-12',
-      rdfDownloadUrl: 'https://archive.monarchinitiative.org/201910/rdf/clinvar.nt'
+      rdfDownloadUrl: 'https://archive.monarchinitiative.org/201911/rdf/clinvar.nt'
     },
     {
       sourceDisplayName: "Undiagnosed Diseases Program (UDP)",
@@ -299,7 +299,7 @@ export default function getStaticSourceData() {
 
       // this will need updating periodically:
       ingestDate: '2019-03-16',
-      rdfDownloadUrl: 'https://archive.monarchinitiative.org/201910/rdf/udp.ttl',
+      rdfDownloadUrl: 'https://archive.monarchinitiative.org/201911/rdf/udp.ttl',
     }
   ];
 

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -177,11 +177,11 @@
       BETA
     </div>
     <div v-if="getEnvironment() != 'production'" class="production">
-        <b-navbar-nav>
-           <b-nav-item href="https://monarchinitiative.org/" target="_blank">
-            Main Site
-          </b-nav-item>
-        </b-navbar-nav>
+      <b-navbar-nav>
+        <b-nav-item href="https://monarchinitiative.org/" target="_blank">
+          Main Site
+        </b-nav-item>
+      </b-navbar-nav>
     </div>
   </b-navbar>
 


### PR DESCRIPTION
- Manually set ingest dates for ClinVar (no metadata yet for this ingest) and UDP (ingest hasn't been run in a while, so no up-to-date metadata)
- Also remove GeneReviews, since it isn't loaded currently
- Linting