### PR TITLE
Make about licensing page

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -41,6 +41,10 @@
             Our Team
           </b-dropdown-item>
 
+          <b-dropdown-item to="/about/licensing">
+            Licensing
+          </b-dropdown-item>
+
           <b-dropdown-item to="/about/disclaimer">
             Disclaimer
           </b-dropdown-item>

--- a/src/router.js
+++ b/src/router.js
@@ -64,6 +64,11 @@ const router = new Router({
       component: require('@/views/Disclaimer.md').default,
     },
     {
+      path: '/about/licensing',
+      name: 'about-licensing',
+      component: require('@/views/AboutLicensing.md').default,
+    },
+    {
       path: '/documentation/publications',
       name: 'about-publications',
       component: require('@/views/Publications.md').default,

--- a/src/views/AboutLicensing.md
+++ b/src/views/AboutLicensing.md
@@ -33,7 +33,7 @@
     <li><a href="https://github.com/OBF/FALDO">FALDO</a>: 
     <a href="https://github.com/OBF/FALDO#license">Creative Commons Zero 1.0 Public Domain</a>
     </li>
-    <li><a href="http://www.ontobee.org/ontology/IAO">IAO</a>
+    <li><a href="http://www.ontobee.org/ontology/IAO">IAO: </a>
         <a href="http://www.ontobee.org/ontology/IAO">Creative Commons BY 4.0</a></li>
     <li><a href="https://github.com/monarch-initiative/SEPIO-ontology">SEPIO</a>:
         <a href="https://github.com/monarch-initiative/SEPIO-ontology#license">Creative Commons BY 3.0</a></li>

--- a/src/views/AboutLicensing.md
+++ b/src/views/AboutLicensing.md
@@ -1,0 +1,74 @@
+<div class="container-fluid monarch-view monarch-licensing">
+    <h2 class="page-title">About Licensing</h2>
+    <p>The Monarch App is comprised of multiple different components: interface, data, ontologies, software and algorithms. 
+    It is therefore not possible to provide everything under a unified license. The specific components and their licensing information are below.</p>
+    <h4>Interface</h4>
+    <ul>
+    <li><a href="https://github.com/monarch-initiative/monarch-ui">The Monarch-UI</a></li>
+    </ul>
+    <h4>Algorithms</h4>
+    <ul>
+    <li><a href="https://monarch-exomiser-web-dev.monarchinitiative.org/exomiser/">Exomiser</a>: 
+    <a href="http://opensource.org/licenses/AGPL-3.0"> GNU Affero General Public License, version 3</a></li>
+    <li><a href="https://github.com/owlcollab/owltools/">OwlSim</a>: 
+    <a href="https://github.com/owlcollab/owltools/blob/master/LICENSE.txt">BSD 3 License</a></li>
+    <li><a href="https://github.com/TheJacksonLaboratory/LIRICAL">LIRICAL</a>: 
+    <a href="https://github.com/TheJacksonLaboratory/LIRICAL/blob/master/LICENSE">License information</a></li>
+    </ul>
+    <h4>Semantic tools and workflows</h4>
+    <ul>
+    <li><a href="https://github.com/monarch-initiative/dipper">Dipper</a>: 
+    <a href="https://github.com/monarch-initiative/dipper/blob/master/LICENSE.txt">BSD 3 License</a></li>
+    <li><a href="https://github.com/SciGraph/SciGraph/">SciGraph</a>: 
+    <a href="https://github.com/SciGraph/SciGraph/blob/master/LICENSE">Apache License 2.0</a>
+    </li>
+    <li><a href="https://github.com/biolink/ontobio">OntoBio</a>: 
+    <a href="https://github.com/biolink/ontobio/blob/master/LICENSE">BSD 3 License</a>
+    </li>
+    </ul>    
+    <h4>Ontologies</h4>
+    <!-- via https://github.com/monarch-initiative/scigraph-docker/blob/master/conf/data/monarchLoadConfiguration.yaml.tmpl#L70 -->
+    <ul>
+    <li><a href="https://github.com/OBF/FALDO">FALDO</a>: 
+    <a href="https://github.com/OBF/FALDO#license">Creative Commons Zero 1.0 Public Domain</a>
+    </li>
+    <li><a href="http://www.ontobee.org/ontology/IAO">IAO</a>
+        <a href="http://www.ontobee.org/ontology/IAO">Creative Commons BY 4.0</a></li>
+    <li><a href="https://github.com/monarch-initiative/SEPIO-ontology">SEPIO</a>:
+        <a href="https://github.com/monarch-initiative/SEPIO-ontology#license">Creative Commons BY 3.0</a></li>
+    <li><a href="http://www.ontobee.org/ontology/ERO">ERO</a>: Unknown license</li>
+    <li><a href="http://www.obofoundry.org/ontology/pw.html">PW</a>: 
+        <a href="http://www.obofoundry.org/ontology/pw.html">Creative Commons BY 4.0</a></li>
+    <li><a href="https://github.com/EBISPOT/OBAN/blob/master/README.md">OBAN-CORE: </a>
+        <a href="http://www.obofoundry.org/ontology/pw.html">Creative Commons BY 4.0</a></li>
+    <li><a href="https://github.com/CLO-ontology/CLO/">CLO-CORE</a>: Unknown license</li>
+    <li><a href="http://obofoundry.org/ontology/pco.html">PCO</a>:
+        <a href="http://obofoundry.org/ontology/pco.html">Creative Commons 1.0</a></li>
+    <li><a href="https://www.ebi.ac.uk/ols/ontologies/xco">XCO</a>: Unknown license</li>
+    <li><a href="http://www.foaf-project.org/">FOAF</a>: Unknown license</li>
+    <li><a href="https://bioportal.bioontology.org/ontologies/DC">DC</a>:
+        <a href="https://dublincore.org/">Creative Commons Attribution 3.0 Unported License</a></li>
+    </ul>
+    <h4>Other Standards</h4>
+    <ul>
+    <li><a href="https://github.com/phenopackets/phenopacket-schema">Phenopackets</a>: 
+    <a href="https://github.com/phenopackets/phenopacket-schema/blob/master/LICENSE">BSD 3 License</a>
+    </li>
+    <li><a href="https://github.com/biolink/biolink-api">BioLink-api</a>:
+        <a href="https://github.com/biolink/biolink-api/blob/master/LICENSE">BSD 3 License</a></li>
+    <li><a href="https://github.com/biolink/biolink-model">BioLink-model</a>:
+        <a href="https://github.com/biolink/biolink-model/blob/master/LICENSE">Creative Commons Zero v1.0 Universal License</a></li>
+    </ul>
+    <h4>Data</h4>
+    <p>Data are derived from multiple sources (see <a href="/about/data-sources">here</a>), each with its own license. We
+    have described this licensing challenge extensively on <a href="reusabledata.org">reusabledata.org</a> and our
+    <a href="https://doi.org/10.1371/journal.pone.0213090">2018 PlosOne publication</a>. Many of the specific data
+    resources we use in Monarch have been evaluated according to our reusabledata.org rubric; see the corpus of
+    evaluations <a href="http://reusabledata.org/#our-sources-data">here</a>.</p>
+</div>
+
+<script>
+</script>
+
+<style lang="scss">
+</style>

--- a/src/views/AboutLicensing.md
+++ b/src/views/AboutLicensing.md
@@ -4,7 +4,8 @@
     It is therefore not possible to provide everything under a unified license. The specific components and their licensing information are below.</p>
     <h4>Interface</h4>
     <ul>
-    <li><a href="https://github.com/monarch-initiative/monarch-ui">The Monarch-UI</a></li>
+    <li><a href="https://github.com/monarch-initiative/monarch-app/">The Monarch-App: </a>
+    <a href="https://github.com/monarch-initiative/monarch-app/blob/master/LICENSE.txt">BSD 3 License</a></li>
     </ul>
     <h4>Algorithms</h4>
     <ul>


### PR DESCRIPTION
Trying to make some progress on (and heaven forfend, actual close!) [this ticket](https://github.com/monarch-initiative/monarch-ui/issues/186) - I made this PR, which basically turns Google Doc with an AboutLicensing page:
https://docs.google.com/document/d/1xeD2NEZvzVQrn16-oDwodqxVZV04OVX63Ch5yXWQ41s/edit#
Into this actual Monarch-UI page:
https://justaddcoffee.github.io/monarch-ui/about/licensing

@jmcmurry @monicacecilia have a look

Does anyone have licensing info for the monarch-ui itself? Can't find this info anywhere. Also, on that page, there are a few "Unknown License" items that you guys might have info about?
