### PR TITLE
Fix predicate to retrieve logo URL from metadata

### DIFF
--- a/src/api/BBOPGraphUtil.js
+++ b/src/api/BBOPGraphUtil.js
@@ -112,13 +112,17 @@ export function populateRdfDownloadUrl(sourceData, graph) {
   for (let i = 0; i < sourceData.length; i++) {
     const distributionIRI = _versionIRI2distributionIRI(sourceData[i]._version_iri, graph);
     const downloadUrl = _subjectPredicate2Object(distributionIRI, predicates.downloadUrl, graph);
-    sourceData[i].rdfDownloadUrl = downloadUrl.replace('MonarchArchive:', curiePrefixURLs.MonarchArchive);
+    if (downloadUrl != undefined) {
+      sourceData[i].rdfDownloadUrl = downloadUrl.replace('MonarchArchive:', curiePrefixURLs.MonarchArchive);
+    }
   }
 }
 
 export function populateLogoUrl(sourceData, graph) {
   for (let i = 0; i < sourceData.length; i++) {
     const logoUrl = _subjectPredicate2Object(sourceData[i]._summary_iri, predicates.logo, graph);
-    sourceData[i].logoUrl = logoUrl.replace('MonarchLogoRepo:', curiePrefixURLs.MonarchLogoRepo);
+    if (logoUrl != undefined) {
+      sourceData[i].logoUrl = logoUrl.replace('MonarchLogoRepo:', curiePrefixURLs.MonarchLogoRepo);
+    }
   }
 }

--- a/src/api/BBOPGraphUtil.js
+++ b/src/api/BBOPGraphUtil.js
@@ -9,7 +9,7 @@ const predicates = { // predicates used to retrieve items from BBOP graph json e
   'retrievedOn': 'http://purl.org/pav/retrievedOn',
   'created': 'http://purl.org/dc/terms/created',
   'downloadUrl': 'dcterms:downloadURL',
-  'logo': 'schemaorg:logo',
+  'logo': 'schema:logo',
 };
 
 const curiePrefixURLs = { // various curie prefixes that need to be fixed/expanded to URLs

--- a/src/views/Sources.vue
+++ b/src/views/Sources.vue
@@ -17,7 +17,7 @@
             <b-button v-b-toggle="'collapse-' + index" variant="primary" class="btn btn-info">More info</b-button>
             <b-collapse :id="'collapse-' + index" class="mt-2">
                 <b-card>
-                  <img :src="source.logoUrl" >
+                  <img v-if="source.logoUrl" :src="source.logoUrl" >
                   <div class="display-name">
                     {{ source.sourceDescription }}
                   </div>


### PR DESCRIPTION
`schemaorg:logo` changed to `schema:logo` 