### PR TITLE
Make menu item for Ontologies

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -45,6 +45,10 @@
             Licensing
           </b-dropdown-item>
 
+          <b-dropdown-item to="/about/licensing#ontologies">
+            Ontologies
+          </b-dropdown-item>
+
           <b-dropdown-item to="/about/disclaimer">
             Disclaimer
           </b-dropdown-item>

--- a/src/views/Licensing.vue
+++ b/src/views/Licensing.vue
@@ -28,7 +28,7 @@
     <a href="https://github.com/biolink/ontobio/blob/master/LICENSE">BSD 3 License</a>
     </li>
     </ul>
-    <h4>Ontologies maintained by Monarch</h4>
+    <h4 id="ontologies">Ontologies maintained by Monarch</h4>
         <ul>
             <div v-for="ontology in ontologyLicenseInfo.ontologies">
             <li v-if="['ecto', 'geno', 'hp', 'maxo', 'mondo', 'sepio', 'upheno'].includes(ontology.id)">


### PR DESCRIPTION
Make menu item for Ontologies that links to section in about/license that describes MI ontologies (per Moni's request here #296)

