### PR TITLE
phenogrid fixes, change noncausal to correlated

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lodash": "^4.17.15",
     "markdown-it": "^10.0.0",
     "markdown-it-anchor": "^5.2.5",
-    "phenogrid": "^1.5.0",
+    "phenogrid": "git://github.com/kshefchek/phenogrid.git#1.5.1",
     "register-service-worker": "^1.6.2",
     "sanitize-html": "^1.20.1",
     "underscore": "^1.9.2",

--- a/src/api/BioLink.js
+++ b/src/api/BioLink.js
@@ -461,9 +461,9 @@ function getBiolinkAnnotation(cardType) {
     result = 'ortholog/phenotypes';
   } else if (cardType === 'ortholog-disease') {
     result = 'ortholog/diseases';
-  } else if (cardType === 'causal-disease' || cardType === 'noncausal-disease') {
+  } else if (cardType === 'causal-disease' || cardType === 'correlated-disease') {
     result = 'diseases';
-  } else if (cardType === 'causal-gene' || cardType === 'noncausal-gene') {
+  } else if (cardType === 'causal-gene' || cardType === 'correlated-gene') {
     result = 'genes';
   } else if (cardType === 'function') {
     result = cardType;
@@ -485,6 +485,7 @@ export async function getNodeAssociations(
   let url = `${baseUrl}${urlExtension}`;
   const useTaxonRestriction = taxons && taxons.length > 0 && isTaxonCardType(cardType);
 
+  params.unselect_evidence = true;
 
   // Use monarch solr until amigo-ontobio connection is ready
   if (cardType === 'function') {
@@ -494,7 +495,7 @@ export async function getNodeAssociations(
 
   if (cardType.startsWith('causal')) {
     params.association_type = 'causal';
-  } else if (cardType.startsWith('noncausal')) {
+  } else if (cardType.startsWith('correlated')) {
     params.association_type = 'non_causal';
   }
 

--- a/src/components/AssocTable.vue
+++ b/src/components/AssocTable.vue
@@ -433,12 +433,12 @@ export default {
           objectTaxon = this.parseTaxon(objectElem);
         } else if (
           modifiedCardType === 'causal-disease'
-          || modifiedCardType === 'noncausal-disease'
+          || modifiedCardType === 'correlated-disease'
         ) {
           modifiedCardType = 'disease';
         } else if (
           modifiedCardType === 'causal-gene'
-          || modifiedCardType === 'noncausal-gene'
+          || modifiedCardType === 'correlated-gene'
         ) {
           modifiedCardType = 'gene';
         }

--- a/src/components/PhenoGrid.vue
+++ b/src/components/PhenoGrid.vue
@@ -7,6 +7,7 @@
 </template>
 
 <script>
+import { biolink } from '@/api/BioLink';
 
 /* global Phenogrid */
 
@@ -53,8 +54,11 @@ export default {
         'yAxis': this.yAxis
       };
 
+      const appBase = window.location.protocol + '//' + window.location.host;
+
       Phenogrid.createPhenogridForElement(this.$refs.phenogridbox, {
-        serverURL: 'https://api.monarchinitiative.org',
+        serverURL: biolink,
+        appURL: appBase,
         gridSkeletonData: pgData,
         selectedCalculation: 0,
         selectedSort: 'Frequency',

--- a/src/components/PhenotypesTable.vue
+++ b/src/components/PhenotypesTable.vue
@@ -65,9 +65,9 @@ export default {
       currentPage: 1,
       filter: '',
       sortBy: 'score',
-      sortDesc: 'true',
+      sortDesc: true,
       fields: [
-         {
+        {
           key: 'hitLabel',
           label: 'Match Label',
           sortable: true
@@ -123,14 +123,14 @@ export default {
     async comparePhenotypes() {
       const that = this;
       try {
-        console.log(this.source);
-        console.log(this.compare);
+        // console.log(this.source);
+        // console.log(this.compare);
         const searchResponse = await bioLinkService.comparePhenotypes(this.source, this.compare, this.mode);
         this.preItems = searchResponse;
         this.dataFetched = true;
       } catch (e) {
         that.dataError = e;
-        console.log('BioLink Error', e);
+        // console.log('BioLink Error', e);
       }
     },
     processItems(){
@@ -140,7 +140,7 @@ export default {
           hitLabel: elem.label,
           hitId: elem.id,
           score: elem.score,
-          taxonLabel: elem.taxon.label  !== null ? elem.taxon.label : "-"
+          taxonLabel: elem.taxon.label !== null ? elem.taxon.label : '-'
         }
         this.items.push(rowData);
       });

--- a/src/views/AnalyzePhenotypes.vue
+++ b/src/views/AnalyzePhenotypes.vue
@@ -349,7 +349,6 @@ import 'vue-form-wizard/dist/vue-form-wizard.min.css';
 import * as biolinkService from '@/api/BioLink';
 import MonarchAutocomplete from '@/components/MonarchAutocomplete.vue';
 import PhenoGrid from '@/components/PhenoGrid.vue';
-import LocalNav from '@/components/LocalNav.vue';
 import PhenotypesTable from '@/components/PhenotypesTable.vue';
 
 Vue.use(VueFormWizard);

--- a/src/views/Node.vue
+++ b/src/views/Node.vue
@@ -203,12 +203,12 @@ const availableCardTypes = [
   'phenotype',
   'gene',
   'causal-gene',
-  'noncausal-gene',
+  'correlated-gene',
   'variant',
   'model',
   'disease',
   'causal-disease',
-  'noncausal-disease',
+  'correlated-disease',
   'pathway',
   'cellline',
   'anatomy',
@@ -227,11 +227,11 @@ const icons = {
   cellline: require('../assets/img/monarch-ui-icon_CELL_LINE.png'),
   disease: require('../assets/img/monarch-ui-icon_DISEASE.png'),
   'causal-disease': require('../assets/img/monarch-ui-icon_DISEASE.png'),
-  'noncausal-disease': require('../assets/img/monarch-ui-icon_DISEASE.png'),
+  'correlated-disease': require('../assets/img/monarch-ui-icon_DISEASE.png'),
   function: require('../assets/img/monarch-ui-icon_FUNCTION.png'),
   gene: require('../assets/img/monarch-ui-icon_GENE.png'),
   'causal-gene': require('../assets/img/monarch-ui-icon_GENE.png'),
-  'noncausal-gene': require('../assets/img/monarch-ui-icon_GENE.png'),
+  'correlated-gene': require('../assets/img/monarch-ui-icon_GENE.png'),
   genotype: require('../assets/img/monarch-ui-icon_GENOTYPE.png'),
   case: require('../assets/img/monarch-ui-icon_DISEASE.png'),
   homolog: require('../assets/img/monarch-ui-icon_HOMOLOG.png'),
@@ -250,11 +250,11 @@ const labels = {
   cellline: 'Cell Line',
   disease: 'Disease',
   'causal-disease': 'Disease (causal)',
-  'noncausal-disease': 'Disease (correlated)',
+  'correlated-disease': 'Disease (correlated)',
   function: 'Function',
   gene: 'Gene',
   'causal-gene': 'Gene (causal)',
-  'noncausal-gene': 'Gene (correlated)',
+  'correlated-gene': 'Gene (correlated)',
   genotype: 'Genotype',
   case: 'Case',
   homolog: 'Homolog',
@@ -499,6 +499,14 @@ export default {
       this.path = this.$route.path;
       this.nodeId = this.$route.params.id;
       this.nodeType = this.path.split('/')[1];
+
+      // copying from old app bbop.monarch.Engine.prototype.convertIdToCurie
+      // Looks like people still link to terms using fragment format instead of curie
+      // eg IMPC phenogrid https://www.mousephenotype.org/data/genes/MGI:98297
+      if (/_/.test(this.nodeId) && !/:/.test(this.nodeId)) {
+        const newNodeId = this.nodeId.replace('_', ':');
+        this.$router.push(newNodeId);
+      }
 
       // TIP: setup the pre-fetch state, waiting for the async result
       this.node = null;


### PR DESCRIPTION
- Bumps phenogrid to test branch 1.5.1 which includes small fixes
- Replaces noncausal (genes|diseases) with correlated
- add unselect_evidence=true for biolink calls since this is no longer needed
- Support fragment formatted identifiers (eg HP_1234) after reviewing IMPC phenogrid

fixes #283 
