### PR TITLE
fixes #346, broken JBrowse link

### DIFF
--- a/src/api/MyGene.js
+++ b/src/api/MyGene.js
@@ -118,7 +118,7 @@ export async function getGeneDescription(geneId) {
           const defaultTrackName = 'All Genes'; // this is the generic track name
           const locationString = locationObj.chr + ':' + locationObj.start + '..' + locationObj.end;
           const apolloServerPrefix = 'https://agr-apollo.berkeleybop.io/apollo/';
-          const externalUrl = 'http://jbrowse.alliancegenome.org/jbrowse/index.html?data=data/' + encodeURI(thisSpecies) + '&loc=' + encodeURI(locationString);
+          const externalUrl = 'http://www.alliancegenome.org/jbrowse/index.html?data=data/' + encodeURI(thisSpecies) + '&loc=' + encodeURI(locationString) + '&tracks=' + defaultTrackName;
           const trackDataPrefix = apolloServerPrefix + 'track/' + encodeURI(thisSpecies) + '/' + defaultTrackName + '/' + encodeURI(locationString) + '.json';
           const trackDataWithHighlightURL = trackDataPrefix + '?name=' + symbol;
           // console.log('trackDataWithHighlight', trackDataWithHighlightURL);


### PR DESCRIPTION
Fixes the bad link to JBrowse; also adds the default track to the JBrowse URL parameters so that at least one view of the tracks will be displayed