### PR TITLE
only remove leading zeroes when building GARD URLs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "monarch-ui",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/views/Node.vue
+++ b/src/views/Node.vue
@@ -929,7 +929,7 @@ export default {
             return true;
           }
         } else if (xref.id.includes('GARD')) {
-          const urlId = xref.id.replace(/^GARD:(0)+/g, '');
+          const urlId = xref.id.replace(/^GARD:(0)*/g, '');
           const urlLabel = this.node.label.replace(/\s/g, '-');
           xref.uri = `https://rarediseases.info.nih.gov/diseases/${urlId}/${urlLabel.toLowerCase()}`;
           xref.label = 'GARD';

--- a/src/views/Node.vue
+++ b/src/views/Node.vue
@@ -929,8 +929,7 @@ export default {
             return true;
           }
         } else if (xref.id.includes('GARD')) {
-          let urlId = xref.id.replace('GARD:', '');
-          urlId = urlId.replace(/0/g, '');
+          const urlId = xref.id.replace(/^GARD:(0)+/g, '');
           const urlLabel = this.node.label.replace(/\s/g, '-');
           xref.uri = `https://rarediseases.info.nih.gov/diseases/${urlId}/${urlLabel.toLowerCase()}`;
           xref.label = 'GARD';


### PR DESCRIPTION
I noticed that the GARD link for MONDO:0018484 was pointing to 

https://rarediseases.info.nih.gov/diseases/1993/semicircular-canal-dehiscence-syndrome

rather than 

https://rarediseases.info.nih.gov/diseases/10993/semicircular-canal-dehiscence-syndrome

I was going to just create an issue, but it was such an odd error that I went looking for it on my own. It made a lot more sense once I saw the necessary ID->url conversion. 