### PR TITLE
add SameSite header to gtag

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -21,8 +21,7 @@ if (productionServers.includes(window.location.hostname)) {
       id: 'UA-41803362-1',
       params: {
         anonymize_ip: true,
-        cookie_domain: "monarchinitiative.org",
-        cookie_flags: "SameSite=None;Secure",
+        cookie_flags: 'SameSite=None;Secure',
       }
     }
   }, router);

--- a/src/main.js
+++ b/src/main.js
@@ -20,7 +20,9 @@ if (productionServers.includes(window.location.hostname)) {
     config: {
       id: 'UA-41803362-1',
       params: {
-        anonymize_ip: true
+        anonymize_ip: true,
+        cookie_domain: "monarchinitiative.org",
+        cookie_flags: "SameSite=None;Secure",
       }
     }
   }, router);


### PR DESCRIPTION
I'm currently seeing the warning:

> Cookie “_ga” will be soon rejected because it has the “SameSite” attribute set to “None” or an invalid value, without the “secure” attribute. To know more about the “SameSite“ attribute, read https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie/SameSite

adding this cookie_flag should fix this
