### PR TITLE
Add flag to test out new google cloud versions of apis

### DIFF
--- a/src/api/BioLink.js
+++ b/src/api/BioLink.js
@@ -17,8 +17,9 @@ import { labelToId, isTaxonCardType, isSubjectCardType } from '../lib/TaxonMap';
 
 // versions/environments of api servers
 const versions = {
-  beta: 'https://api-dev.monarchinitiative.org/api/',
-  production: 'https://api.monarchinitiative.org/api/'
+  'google-cloud': 'https://api.monarch-test.ddns.net/api/',
+  'beta': 'https://api-dev.monarchinitiative.org/api/',
+  'production': 'https://api.monarchinitiative.org/api/'
 };
 
 const defaultVersion = 'production';

--- a/src/api/BioLink.js
+++ b/src/api/BioLink.js
@@ -17,6 +17,7 @@ import { labelToId, isTaxonCardType, isSubjectCardType } from '../lib/TaxonMap';
 
 // versions/environments of api servers
 const versions = {
+  // WHEN NEW GOOGLE CLOUD SERVICES STABLE, REMOVE FIRST ENTRY AND REPLACE LATTER TWO
   'google-cloud': 'https://api.monarch-test.ddns.net/api/',
   'beta': 'https://api-dev.monarchinitiative.org/api/',
   'production': 'https://api.monarchinitiative.org/api/'

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -184,14 +184,14 @@
 
     <b-navbar-toggle target="nav_collapse" />
     <div
-      v-if="apiVersion === 'beta'"
-      v-b-popover.hover.v-danger.bottomleft="'You are currently on our BETA site. The Monarch Initiative is in the process of creating a new experience for you. We are currently assessing UI functionality and data quality, if you believe you see an issue or want to suggest content please see the footer of this page.'"
-      title="Monarch UI BETA"
+      v-if="apiVersion !== 'production'"
+      v-b-popover.hover.v-danger.bottomleft="'You are currently using a beta version of our APIs. The Monarch Initiative is in the process of creating a new experience for you. If you believe you see an issue or want to suggest content please see the footer of this page.'"
+      title="Monarch APIs BETA"
       class="beta"
     >
       BETA
     </div>
-    <div v-if="apiVersion === 'beta'" class="production">
+    <div v-if="apiVersion !== 'production'" class="production">
       <b-navbar-nav>
         <b-nav-item href="https://monarchinitiative.org/" target="_blank">
           Main Site


### PR DESCRIPTION
- adds flag `?api=google-cloud` to enable testing of the new google cloud services. this should only be temporary while we migrate over to google cloud.
- changes the wording of the beta warning a bit