### PR TITLE
avoid errors when api flag value not found, change gc comment

### DIFF
--- a/src/api/BioLink.js
+++ b/src/api/BioLink.js
@@ -17,8 +17,7 @@ import { labelToId, isTaxonCardType, isSubjectCardType } from '../lib/TaxonMap';
 
 // versions/environments of api servers
 const versions = {
-  // WHEN NEW GOOGLE CLOUD SERVICES STABLE, REMOVE FIRST ENTRY AND REPLACE LATTER TWO
-  'google-cloud': 'https://api.monarch-test.ddns.net/api/',
+  'google-cloud': 'https://api.monarch-test.ddns.net/api/',  // REMOVE WHEN NEW GOOGLE CLOUD SERVICES STABLE AND CANONICAL URLS BELOW HAVE BEEN TRANSFERRED TO THEM
   'beta': 'https://api-dev.monarchinitiative.org/api/',
   'production': 'https://api.monarchinitiative.org/api/'
 };
@@ -27,7 +26,7 @@ const defaultVersion = 'production';
 
 const versionOverride = new URLSearchParams(document.location.search.substring(1)).get('api');
 
-export const version = versionOverride || defaultVersion;
+export const version = versionOverride && versions[versionOverride] ? versionOverride : defaultVersion;
 
 export const biolink = versions[version];
 


### PR DESCRIPTION
Came across errors when i tried to do `?api=google-cloud` on the live site, but the pr that added that particular flag hadn't went live yet. This makes it so if user types in not supported flag, like `?api=tomatoes`, it defaults to production.