### PR TITLE
Phenogrid fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11936,15 +11936,48 @@
       "dev": true
     },
     "gulp-uglify-es": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-uglify-es/-/gulp-uglify-es-2.0.0.tgz",
-      "integrity": "sha512-00KkawzjWdjPo1YfD1FXKijVxZkyr6YSwJ2cJQgD1fNKFZCFPNjGc5sTyzyW8tZns8FmZafgHMrg7LUDNvIQ5A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-uglify-es/-/gulp-uglify-es-3.0.0.tgz",
+      "integrity": "sha512-dQ3czMFFojNgCajcrYl0oa98+YayaQ8kXRdaacpZRZ3iw2sdVURfdt8y8Ki1ogZGQqw8BUawnB7V6NkanxqnDg==",
       "requires": {
-        "o-stream": "^0.2.2",
+        "o-stream": "^0.3.0",
         "plugin-error": "^1.0.1",
-        "terser": "^4.3.9",
-        "vinyl": "^2.2.0",
+        "terser": "^5.7.1",
+        "vinyl": "^2.2.1",
         "vinyl-sourcemaps-apply": "^0.2.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+        },
+        "source-map-support": {
+          "version": "0.5.19",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+          "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+            }
+          }
+        },
+        "terser": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.1.tgz",
+          "integrity": "sha512-b3e+d5JbHAe/JSjwsC3Zn55wsBIM7AsHLjKxT31kGCldgbpFePaFo+PiddtO6uwRZWRw7sPXmAN8dTW61xmnSg==",
+          "requires": {
+            "commander": "^2.20.0",
+            "source-map": "~0.7.2",
+            "source-map-support": "~0.5.19"
+          }
+        }
       }
     },
     "gzip-size": {
@@ -13259,9 +13292,9 @@
       }
     },
     "jquery": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
-      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
+      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
     },
     "jquery-ui": {
       "version": "1.12.1",
@@ -15969,9 +16002,9 @@
       "dev": true
     },
     "o-stream": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/o-stream/-/o-stream-0.2.2.tgz",
-      "integrity": "sha512-V3j76KU3g/Gyl8rpdi2z72rn5zguMvTCQgAXfBe3pxEefKqXmOUOD7mvx/mNjykdxGqDVfpSoo8r+WdrkWg/1Q=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/o-stream/-/o-stream-0.3.0.tgz",
+      "integrity": "sha512-gbzl6qCJZ609x/M2t25HqCYQagFzWYCtQ84jcuObGr+V8D1Am4EVubkF4J+XFs6ukfiv96vNeiBb8FrbbMZYiQ=="
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -16773,15 +16806,14 @@
       "dev": true
     },
     "phenogrid": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/phenogrid/-/phenogrid-1.5.1.tgz",
-      "integrity": "sha512-Ct37UP8dEDYtIsTmiL6ECTWFZjgyZxfHJApwimF0rvXfUzRnoxkk8FmiZeHjYmEUzmOE7TRiajl4AcCbtHJEsw==",
+      "version": "github:falquaddoomi/phenogrid#909c92102f853f8d976d6ff214a2505987ca9e73",
+      "from": "github:falquaddoomi/phenogrid#gulp4-upgrade",
       "requires": {
         "d3": "5.7.0",
         "font-awesome": "4.7.0",
-        "gulp-uglify-es": "^2.0.0",
-        "jquery": "^3.3.1",
-        "jquery-ui": "1.12.1",
+        "gulp-uglify-es": "^3.0.0",
+        "jquery": "^3.6.0",
+        "jquery-ui": "^1.12.1",
         "normalize.css": "8.0.1"
       },
       "dependencies": {
@@ -18481,9 +18513,9 @@
       }
     },
     "replace-ext": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.1.tgz",
+      "integrity": "sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw=="
     },
     "request": {
       "version": "2.88.0",
@@ -21392,9 +21424,9 @@
       }
     },
     "vinyl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
-      "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.1.tgz",
+      "integrity": "sha512-LII3bXRFBZLlezoG5FfZVcXflZgWP/4dCwKtxd5ky9+LOtM4CS3bIRQsmR1KMnMW07jpE8fqR2lcxPZ+8sJIcw==",
       "requires": {
         "clone": "^2.1.1",
         "clone-buffer": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11936,48 +11936,15 @@
       "dev": true
     },
     "gulp-uglify-es": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-uglify-es/-/gulp-uglify-es-3.0.0.tgz",
-      "integrity": "sha512-dQ3czMFFojNgCajcrYl0oa98+YayaQ8kXRdaacpZRZ3iw2sdVURfdt8y8Ki1ogZGQqw8BUawnB7V6NkanxqnDg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-uglify-es/-/gulp-uglify-es-2.0.0.tgz",
+      "integrity": "sha512-00KkawzjWdjPo1YfD1FXKijVxZkyr6YSwJ2cJQgD1fNKFZCFPNjGc5sTyzyW8tZns8FmZafgHMrg7LUDNvIQ5A==",
       "requires": {
-        "o-stream": "^0.3.0",
+        "o-stream": "^0.2.2",
         "plugin-error": "^1.0.1",
-        "terser": "^5.7.1",
-        "vinyl": "^2.2.1",
+        "terser": "^4.3.9",
+        "vinyl": "^2.2.0",
         "vinyl-sourcemaps-apply": "^0.2.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
-        },
-        "source-map-support": {
-          "version": "0.5.19",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-          "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-          "requires": {
-            "buffer-from": "^1.0.0",
-            "source-map": "^0.6.0"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-            }
-          }
-        },
-        "terser": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.1.tgz",
-          "integrity": "sha512-b3e+d5JbHAe/JSjwsC3Zn55wsBIM7AsHLjKxT31kGCldgbpFePaFo+PiddtO6uwRZWRw7sPXmAN8dTW61xmnSg==",
-          "requires": {
-            "commander": "^2.20.0",
-            "source-map": "~0.7.2",
-            "source-map-support": "~0.5.19"
-          }
-        }
       }
     },
     "gzip-size": {
@@ -16002,9 +15969,9 @@
       "dev": true
     },
     "o-stream": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/o-stream/-/o-stream-0.3.0.tgz",
-      "integrity": "sha512-gbzl6qCJZ609x/M2t25HqCYQagFzWYCtQ84jcuObGr+V8D1Am4EVubkF4J+XFs6ukfiv96vNeiBb8FrbbMZYiQ=="
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/o-stream/-/o-stream-0.2.2.tgz",
+      "integrity": "sha512-V3j76KU3g/Gyl8rpdi2z72rn5zguMvTCQgAXfBe3pxEefKqXmOUOD7mvx/mNjykdxGqDVfpSoo8r+WdrkWg/1Q=="
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -16806,14 +16773,15 @@
       "dev": true
     },
     "phenogrid": {
-      "version": "github:falquaddoomi/phenogrid#909c92102f853f8d976d6ff214a2505987ca9e73",
-      "from": "github:falquaddoomi/phenogrid#gulp4-upgrade",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/phenogrid/-/phenogrid-1.5.1.tgz",
+      "integrity": "sha512-Ct37UP8dEDYtIsTmiL6ECTWFZjgyZxfHJApwimF0rvXfUzRnoxkk8FmiZeHjYmEUzmOE7TRiajl4AcCbtHJEsw==",
       "requires": {
         "d3": "5.7.0",
         "font-awesome": "4.7.0",
-        "gulp-uglify-es": "^3.0.0",
-        "jquery": "^3.6.0",
-        "jquery-ui": "^1.12.1",
+        "gulp-uglify-es": "^2.0.0",
+        "jquery": "^3.3.1",
+        "jquery-ui": "1.12.1",
         "normalize.css": "8.0.1"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lodash": "^4.17.15",
     "markdown-it": "^10.0.0",
     "markdown-it-anchor": "^5.2.5",
-    "phenogrid": "github:falquaddoomi/phenogrid#gulp4-upgrade",
+    "phenogrid": "^1.5.2",
     "register-service-worker": "^1.7.1",
     "sanitize-html": "^2.3.2",
     "underscore": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lodash": "^4.17.15",
     "markdown-it": "^10.0.0",
     "markdown-it-anchor": "^5.2.5",
-    "phenogrid": "^1.5.1",
+    "phenogrid": "github:falquaddoomi/phenogrid#gulp4-upgrade",
     "register-service-worker": "^1.7.1",
     "sanitize-html": "^2.3.2",
     "underscore": "^1.10.1",

--- a/src/components/PhenoGrid.vue
+++ b/src/components/PhenoGrid.vue
@@ -11,8 +11,6 @@ import { biolink } from '@/api/BioLink';
 
 const Phenogrid = require('phenogrid');
 
-/* global Phenogrid */
-
 export default {
   props: {
     xAxis: {

--- a/src/components/PhenoGrid.vue
+++ b/src/components/PhenoGrid.vue
@@ -9,6 +9,8 @@
 <script>
 import { biolink } from '@/api/BioLink';
 
+const Phenogrid = require('phenogrid');
+
 /* global Phenogrid */
 
 export default {

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,6 @@
 import Vue from 'vue';
 import BootstrapVue from 'bootstrap-vue/dist/bootstrap-vue.esm';
 import 'bootstrap-vue/dist/bootstrap-vue.css';
-// import Phenogrid from 'phenogrid/dist/phenogrid-bundle';
 import 'phenogrid/dist/phenogrid-bundle.css';
 import VueGtag from 'vue-gtag';
 import router from './router';


### PR DESCRIPTION
closes #443 

@falquaddoomi fixed the upstream `phenogrid` issues in https://github.com/monarch-initiative/phenogrid/pull/282 . This updates the version of the `phenogrid` package being used and fixes the import. After the Monarch folks have tested this out in the deploy preview below, we can merge the `phenogrid` pr, publish the new version to npm, change this pr to install from npm (instead of the hacky install from @falquaddoomi 's github repo), then merge this.