### PR TITLE
add workflow to deploy prod to gh-pages

### DIFF
--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -1,14 +1,12 @@
-# workflow that builds production version of app and deploys it to GitHub Pages
-name: Deploy
+name: Deploy Production
 
+# when someone merges a pull request or commits to master
 on:
   push:
     branches:
-      - main
+      - master
 
-env:
-  CI: false
-
+# deploy to github pages
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,32 @@
+# workflow that builds production version of app and deploys it to GitHub Pages
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  CI: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+      - name: Install packages
+        run: yarn install
+      - name: Build app
+        run: yarn build
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          keep_files: false
+          publish_dir: ./dist
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Move production to GitHub Pages to address and close #456 . GitHub Pages doesn't seem to have the same problems as Netlify in China.

After merge, the controller of the monarch domain just needs to [follow these steps](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-an-apex-domain) to make the domain point to GitHub Pages instead of Netlify.