### PR TITLE
Add a category boost for disease and phenotype

### DIFF
--- a/src/api/bio-link.js
+++ b/src/api/bio-link.js
@@ -430,6 +430,8 @@ export async function getSearchTermSuggestions(
   params.append("rows", 10);
   params.append("start", 0);
   params.append("highlight_class", "hilite");
+  params.append("boost_q", "category:disease^5");
+  params.append("boost_q", "category:phenotype^5");
   params.append("boost_q", "category:genotype^-10");
   params.append("boost_q", "category:variant^-35");
   params.append("boost_q", "category:publication^-10");


### PR DESCRIPTION
Adds a solr [boost query](https://solr.apache.org/guide/6_6/the-dismax-query-parser.html#TheDisMaxQueryParser-Thebq_BoostQuery_Parameter) to boost diseases and phenotypes in monarch search and autocomplete.  Also note that this weird ZFIN id "ZFIN:action/marker/view/ZDB-GENE-030131-1577" is gone in beta (https://monarchinitiative.org/?api=beta).  Longer term @kevinschaper had some great ideas on how to improve this, but this will work as a quick fix for now.