### PR TITLE
switch to google cloud version of api for production

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ The VueJS application is built from source code via a modern chain of tools that
 The output of the build process is a set of static files including bundled Javascript, CSS, HTML and other media assets. These are then deployed to Netlify where they can be served to users on the internet.
 
 
+### BioLink Service
+
+There are multiple versions of the BioLink service.
+See the top of the BioLink file in `/api` for what versions are available.
+
+To easily switch between these versions in the live web-app, add a parameter to your current url like `?api=beta`.
+
+
 ### Directory Structure
 
 #### `monarch-ui/`

--- a/README.md
+++ b/README.md
@@ -58,16 +58,6 @@ The VueJS application is built from source code via a modern chain of tools that
 The output of the build process is a set of static files including bundled Javascript, CSS, HTML and other media assets. These are then deployed to Netlify where they can be served to users on the internet.
 
 
-#### BioLink Service
-
-There are two versions of the BioLink service:
- - **beta** at https://api-dev.monarchinitiative.org/api/
- - **production** at https://api.monarchinitiative.org/api/
-
-`monarch-ui` will use **production** by default.
-To override this, put `?api=beta` as a url parameter.
-
-
 ### Directory Structure
 
 #### `monarch-ui/`

--- a/src/api/bio-link.js
+++ b/src/api/bio-link.js
@@ -21,9 +21,8 @@ import {
 
 // versions/environments of api servers
 const versions = {
-  "google-cloud": "https://api.monarch-test.ddns.net/api/", // REMOVE WHEN NEW GOOGLE CLOUD SERVICES STABLE AND CANONICAL URLS BELOW HAVE BEEN TRANSFERRED TO THEM
+  production: "https://api.monarch-test.ddns.net/api/",
   beta: "https://api-dev.monarchinitiative.org/api/",
-  production: "https://api.monarchinitiative.org/api/",
 };
 
 const defaultVersion = "production";


### PR DESCRIPTION
In anticipation of Kent leaving the team, we would like to start more seriously testing the new Google Cloud instance of the API (and other services) with the live web app. This PR switches the production/beta/etc flag on the frontend to use the Google Cloud version by default. Eventually, and soon, we'll want to switch the DNS configuration so that `https://api.monarchinitiative.org/api/` actually points to the Google Cloud instance, and not the instance still running on Oregon State University hardware. Faisal, let me know when you want to make that switch.